### PR TITLE
Merge helper changes from libmodulemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.pyo
 *.pot
 *.po
-*.yaml
 *~
 *.swp
 .idea/*

--- a/ModulemdTranslationHelpers/__init__.py
+++ b/ModulemdTranslationHelpers/__init__.py
@@ -11,6 +11,6 @@
 # For more information on free software, see
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
-from ModulemdTranslationHelpers.Utils import get_module_catalog_from_tags
-from ModulemdTranslationHelpers.Utils import get_modulemd_translations
+from ModulemdTranslationHelpers.Utils import get_translation_catalog_from_index
+from ModulemdTranslationHelpers.Utils import get_modulemd_translations_from_catalog
 import ModulemdTranslationHelpers.Fedora

--- a/ModulemdTranslationHelpers/cli.py
+++ b/ModulemdTranslationHelpers/cli.py
@@ -11,6 +11,12 @@
 # For more information on free software, see
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
+from ModulemdTranslationHelpers.Fedora import get_tags_for_fedora_branch
+from ModulemdTranslationHelpers.Fedora import get_fedora_rawhide_version
+from ModulemdTranslationHelpers.Fedora import KOJI_URL
+from ModulemdTranslationHelpers import get_modulemd_translations
+from ModulemdTranslationHelpers import get_module_catalog_from_tags
+from gi.repository import Modulemd
 from __future__ import print_function
 
 import click
@@ -23,13 +29,7 @@ import xmlrpc.client
 from babel.messages import pofile
 
 gi.require_version('Modulemd', '1.0')
-from gi.repository import Modulemd
 
-from ModulemdTranslationHelpers import get_module_catalog_from_tags
-from ModulemdTranslationHelpers import get_modulemd_translations
-from ModulemdTranslationHelpers.Fedora import KOJI_URL
-from ModulemdTranslationHelpers.Fedora import get_fedora_rawhide_version
-from ModulemdTranslationHelpers.Fedora import get_tags_for_fedora_branch
 
 ##############################################################################
 # Common options for all commands                                            #

--- a/ModulemdTranslationHelpers/tests/TestTranslationHelpers.py
+++ b/ModulemdTranslationHelpers/tests/TestTranslationHelpers.py
@@ -1,0 +1,244 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# This file is part of ModulemdTranslationHelpers
+# Copyright (C) 2018-2019 Stephen Gallagher
+#
+# Fedora-License-Identifier: MIT
+# SPDX-2.0-License-Identifier: MIT
+# SPDX-3.0-License-Identifier: MIT
+#
+# This program is free software.
+# For more information on the license, see COPYING.
+# For more information on free software, see
+# <https://www.gnu.org/philosophy/free-sw.en.html>.
+
+import os
+import sys
+import unittest
+from ModulemdTranslationHelpers import Utils
+from babel.messages import pofile
+from six import text_type
+from unittest import mock
+
+try:
+    import gi
+    gi.require_version('Modulemd', '2.0')
+    from gi.repository import Modulemd
+except ImportError:
+    # Return error 77 to skip this test on platforms without the necessary
+    # python modules
+    sys.exit(77)
+
+from unittest import TestCase
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class KojiSessionMock:
+
+    def __init__(self):
+        with open("%s/test_data/f29_build_1.yaml" % THIS_DIR, 'r') as file:
+            self.build_1_yaml = file.read()
+
+        with open("%s/test_data/f29_build_2.yaml" % THIS_DIR, 'r') as file:
+            self.build_2_yaml = file.read()
+
+    def listTagged(self, tag):
+        tagged_builds = [{
+            'id': 1,
+            'name': 'foo',
+            'version': 'master',
+            'release': '10.1'
+        },
+            {
+            'id': 2,
+            'name': 'bar',
+            'version': 'master',
+            'release': '2.1'
+        }]
+        return tagged_builds
+
+    def getBuild(self, build_id):
+        build = [{
+            'id': 1,
+            'package_name': 'marvel',
+            'nvr': 'black',
+            'extra': {
+                'typeinfo': {
+                    'module': {
+                        'modulemd_str': self.build_1_yaml
+                    }
+                }
+            }
+        },
+            {
+            'id': 2,
+            'package_name': 'marvel',
+            'nvr': 'black',
+            'extra': {
+                'typeinfo': {
+                    'module': {
+                        'modulemd_str': self.build_2_yaml
+                    }
+                }
+            }
+        }]
+
+        if build_id == 1:
+            return build[0]
+        return build[1]
+
+
+class TestTranslationHelpers(TestCase):
+
+    def test_translation_catalog_from_index(self):
+        # Create a Modulemd.ModuleIndex object containing the YAML stream
+        index = Modulemd.ModuleIndex.new()
+        self.assertIsNotNone(index)
+        ret, failures = index.update_from_file(
+            "%s/test_data/f29.yaml" % THIS_DIR, True)
+        self.assertTrue(ret)
+        self.assertTrue(len(failures) == 0)
+
+        # Create a babel catalog for the Modulemd.ModuleIndex object
+        catalog = Utils.get_translation_catalog_from_index(
+            index, "fedora-modularity-translations")
+        self.assertTrue(catalog)
+        # Check if the catalog is internally consistent
+        self.assertTrue(catalog.check())
+
+        # Check if each translatable string is mapped to its correct location
+        for msg in catalog:
+            for location in msg.locations:
+                (module_name, stream_name, string_type,
+                 profile_name) = Utils.split_location(location)
+
+                module = index.get_module(module_name)
+                self.assertIsNotNone(module)
+
+                stream = module.search_streams(stream_name, 0)[0]
+                self.assertIsNotNone(stream)
+
+                if string_type == "summary":
+                    self.assertEqual(stream.get_summary("C"), msg.id)
+                elif string_type == "description":
+                    self.assertEqual(stream.get_description("C"), msg.id)
+                else:
+                    self.assertEqual(string_type, "profile")
+                    profile = stream.get_profile(profile_name)
+                    self.assertIsNotNone(profile)
+                    self.assertEqual(profile.get_description("C"), msg.id)
+
+        # There are 75 unique summaries and descriptions in f29.yaml
+        self.assertEqual(len(catalog), 75)
+
+    def test_translations_from_catalog(self):
+        translation_files = [
+            "%s/test_data/nl.po" % THIS_DIR,
+            "%s/test_data/fr.po" % THIS_DIR,
+            "%s/test_data/sv.po" % THIS_DIR
+        ]
+
+        catalogs = list()
+        for f in translation_files:
+            with open(f, 'r') as infile:
+                catalog = pofile.read_po(infile)
+                self.assertIsNotNone(catalog)
+
+                # Check if the catalog is internally consistent
+                self.assertTrue(catalog.check())
+                catalogs.append(catalog)
+
+        index = Modulemd.ModuleIndex.new()
+        self.assertIsNotNone(index)
+        ret, failures = index.update_from_file(
+            "%s/test_data/f29.yaml" % THIS_DIR, True)
+        self.assertTrue(ret)
+        self.assertTrue(len(failures) == 0)
+
+        Utils.get_modulemd_translations_from_catalog(catalogs, index)
+
+        for catalog in catalogs:
+            for msg in catalog:
+                # Handle UTF-8 differences between python 2 and 3
+                if isinstance(msg.string, str):
+                    msg_string = msg.string
+                elif isinstance(msg.string, text_type):
+                    msg_string = msg.string.encode('utf-8')
+                else:
+                    raise IOError("Message was not a str or text_type")
+
+                for location, _ in msg.locations:
+                    (module_name, stream_name, string_type,
+                     profile_name) = Utils.split_location(location)
+
+                    module = index.get_module(module_name)
+                    self.assertIsNotNone(module)
+
+                    streams = module.search_streams(stream_name, 0)
+                    self.assertIsNotNone(streams)
+
+                    for stream in streams:
+                        if string_type == "summary":
+                            self.assertEqual(
+                                stream.get_summary(
+                                    str(catalog.locale)), msg_string)
+                        elif string_type == "description":
+                            self.assertEqual(
+                                stream.get_description(
+                                    str(catalog.locale)), msg_string)
+                        else:
+                            self.assertEqual(string_type, "profile")
+                            profile = stream.get_profile(profile_name)
+                            self.assertIsNotNone(profile)
+                            self.assertEqual(
+                                profile.get_description(
+                                    str(catalog.locale)), msg_string)
+
+    @mock.patch('koji.ClientSession')
+    def test_index_from_tags(self, mock_session):
+        koji_session_mock = KojiSessionMock()
+        tags = ['f29']
+
+        # Create a Modulemd.ModuleIndex object containing the YAML stream
+        idx = Modulemd.ModuleIndex.new()
+        self.assertIsNotNone(idx)
+        ret, failures = idx.update_from_file(
+            "%s/test_data/builds.yaml" % THIS_DIR, True)
+        self.assertTrue(ret)
+        self.assertTrue(len(failures) == 0)
+
+        # Test when koji returns no modules
+        mock_session.listTagged.return_value = []
+        mock_session.getBuild.return_value = None
+
+        index = Utils.get_index_from_tags(mock_session, tags)
+        self.assertIsNotNone(index)
+        mock_session.listTagged.assert_called_once_with('f29')
+        self.assertListEqual(index.get_module_names(), [])
+        mock_session.reset_mock()
+
+        # Test when koji returns proper modules
+        mock_session.listTagged.side_effect = koji_session_mock.listTagged
+        mock_session.getBuild.side_effect = koji_session_mock.getBuild
+
+        index = Utils.get_index_from_tags(mock_session, tags)
+        self.assertIsNotNone(index)
+        mock_session.listTagged.assert_called_once_with('f29')
+        mock_session.getBuild.assert_called_with(2)
+        self.assertEqual(idx.dump_to_string(), index.dump_to_string())
+        self.assertListEqual(index.get_module_names(), ['ant', 'avocado'])
+        module = index.get_module('ant')
+        self.assertIsNotNone(module)
+        stream = module.get_stream_by_NSVCA(
+            "1.10", 20180629154141, "819b5873")
+        self.assertIsNotNone(stream)
+        self.assertEqual(stream.get_nsvc(),
+                         "ant:1.10:20180629154141:819b5873")
+        self.assertEqual(stream.get_summary(None), "Java build tool")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ModulemdTranslationHelpers/tests/test_data/builds.yaml
+++ b/ModulemdTranslationHelpers/tests/test_data/builds.yaml
@@ -1,0 +1,211 @@
+---
+document: modulemd
+version: 2
+data:
+  name: ant
+  stream: 1.10
+  version: 20180629154141
+  context: 819b5873
+  arch: x86_64
+  summary: Java build tool
+  description: >-
+    Apache Ant is a Java library and command-line tool whose mission is to drive processes
+    described in build files as targets and extension points dependent upon each other.
+    The main known usage of Ant is the build of Java applications. Ant supplies a
+    number of built-in tasks allowing to compile, assemble, test and run Java applications.
+    Ant can also be used effectively to build non Java applications, for instance
+    C or C++ applications. More generally, Ant can be used to pilot any type of process
+    which can be described in terms of targets and tasks.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/ant.git?#efb686945a977ec8322eca2401e96e8da0f4e3f2
+      commit: efb686945a977ec8322eca2401e96e8da0f4e3f2
+      buildrequires:
+        javapackages-tools:
+          ref: 1e429a4d686d3fdd1d93ce7e8ac7254148ea3471
+          stream: 201801
+          context: b43b0c8f
+          version: 20180629150827
+          filtered_rpms: []
+        platform:
+          ref: virtual
+          stream: f28
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        ant:
+          ref: 1b60ebd3ac34e2c4648c4a5377c9e51fc44d658c
+  dependencies:
+  - requires:
+      platform: []
+  profiles:
+    default:
+      rpms:
+      - ant
+  api:
+    rpms:
+    - ant
+  filter:
+    rpms:
+    - ant-antlr
+    - ant-apache-bcel
+    - ant-apache-bsf
+    - ant-apache-log4j
+    - ant-apache-oro
+    - ant-apache-regexp
+    - ant-apache-resolver
+    - ant-apache-xalan2
+    - ant-commons-logging
+    - ant-commons-net
+    - ant-javadoc
+    - ant-javamail
+    - ant-jdepend
+    - ant-jmf
+    - ant-jsch
+    - ant-junit
+    - ant-manual
+    - ant-swing
+    - ant-testutil
+    - ant-xz
+  buildopts:
+    rpms:
+      macros: |
+        %_with_xmvn_javadoc 1
+        %_without_asciidoc 1
+        %_without_avalon 1
+        %_without_bouncycastle 1
+        %_without_cython 1
+        %_without_dafsa 1
+        %_without_desktop 1
+        %_without_doxygen 1
+        %_without_dtd 1
+        %_without_eclipse 1
+        %_without_ehcache 1
+        %_without_emacs 1
+        %_without_equinox 1
+        %_without_fop 1
+        %_without_ftp 1
+        %_without_gradle 1
+        %_without_groovy 1
+        %_without_hadoop 1
+        %_without_hsqldb 1
+        %_without_itext 1
+        %_without_jackson 1
+        %_without_jmh 1
+        %_without_jna 1
+        %_without_jpa 1
+        %_without_junit5 1
+        %_without_logback 1
+        %_without_markdown 1
+        %_without_memcached 1
+        %_without_memoryfilesystem 1
+        %_without_obr 1
+        %_without_python 1
+        %_without_reporting 1
+        %_without_scm 1
+        %_without_snappy 1
+        %_without_spring 1
+        %_without_ssh 1
+        %_without_testlib 1
+  components:
+    rpms:
+      ant:
+        rationale: 'Module API.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/ant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/ant
+        ref: javapackages
+        buildorder: 10
+  artifacts:
+    rpms:
+    - ant-0:1.10.4-1.module_1886+ece9a977.noarch
+    - ant-lib-0:1.10.4-1.module_1886+ece9a977.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: avocado
+  stream: stable
+  version: 20180816135414
+  context: 6c81f848
+  arch: x86_64
+  summary: Framework with tools and libraries for Automated Testing
+  description: >-
+    Avocado is a set of tools and libraries (what people call these days a framework)
+    to perform automated testing.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2
+    - GPLv2 and MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/avocado.git?#10208a3095f9522485b933dbab830e3338af95e6
+      commit: 10208a3095f9522485b933dbab830e3338af95e6
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        python-avocado:
+          ref: 87dc683a36d0862340d3af99b78fa189a1aba424
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://avocado-framework.github.io/
+    documentation: http://avocado-framework.readthedocs.io/
+    tracker: https://github.com/avocado-framework/avocado/issues
+  profiles:
+    default:
+      rpms:
+      - python2-avocado
+      - python2-avocado-plugins-output-html
+      - python2-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      rpms:
+      - python2-avocado
+  api:
+    rpms:
+    - python-avocado-examples
+    - python2-avocado
+    - python2-avocado-plugins-output-html
+    - python2-avocado-plugins-resultsdb
+    - python2-avocado-plugins-runner-docker
+    - python2-avocado-plugins-runner-remote
+    - python2-avocado-plugins-runner-vm
+    - python2-avocado-plugins-varianter-yaml-to-mux
+  components:
+    rpms:
+      python-avocado:
+        rationale: Framework with tools and libraries for Automated Testing
+        repository: git://pkgs.fedoraproject.org/rpms/python-avocado
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-avocado
+        ref: master
+  artifacts:
+    rpms:
+    - python-avocado-examples-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-output-html-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-resultsdb-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-docker-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-remote-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-vm-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-varianter-yaml-to-mux-0:52.1-7.module_1939+1f9e88da.noarch
+...

--- a/ModulemdTranslationHelpers/tests/test_data/f29.yaml
+++ b/ModulemdTranslationHelpers/tests/test_data/f29.yaml
@@ -1,0 +1,13496 @@
+---
+document: modulemd
+version: 2
+data:
+  name: testmodule
+  stream: master
+  version: 20180405123256
+  context: c2c572ec
+  arch: x86_64
+  summary: A test module in all its beautiful beauty
+  description: >-
+    This module demonstrates how to write simple modulemd files And can be used for
+    testing the build and release pipeline.
+  license:
+    module:
+    - MIT
+    content:
+    - GPL+ or Artistic
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/testmodule.git?#0d33e028e4561f82ea43f670ee6366675cd6a6fe
+      commit: 0d33e028e4561f82ea43f670ee6366675cd6a6fe
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f29
+          filtered_rpms: []
+          version: 4
+      rpms:
+        perl-List-Compare:
+          ref: c6a689a6ce2683b15b32f83e6cb5d43ffd3816f5
+        tangerine:
+          ref: 239ada495d941ceefd8f359e1d8a47877fbba4a9
+        perl-Tangerine:
+          ref: 7e96446223f1ad84a26c7cf23d6591cd9f6326c6
+      requires:
+        platform:
+          ref: virtual
+          stream: f29
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://fedoraproject.org/wiki/Fedora_Packaging_Guidelines_for_Modules
+  profiles:
+    default:
+      rpms:
+      - tangerine
+  api:
+    rpms:
+    - perl-Tangerine
+    - tangerine
+  components:
+    rpms:
+      perl-List-Compare:
+        rationale: A dependency of tangerine.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-List-Compare
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-List-Compare
+        ref: master
+      perl-Tangerine:
+        rationale: Provides API for this module and is a dependency of tangerine.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Tangerine
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Tangerine
+        ref: 7e96446
+      tangerine:
+        rationale: Provides API for this module.
+        repository: git://pkgs.fedoraproject.org/rpms/tangerine
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/tangerine
+        ref: master
+        buildorder: 10
+  artifacts:
+    rpms:
+    - perl-List-Compare-0:0.53-9.module_1588+5eed94c6.noarch
+    - perl-Tangerine-0:0.22-2.module_1588+5eed94c6.noarch
+    - tangerine-0:0.22-7.module_1588+5eed94c6.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: stratis
+  stream: master
+  version: 20180726133047
+  context: b33445dc
+  arch: x86_64
+  summary: Stratis Storage
+  description: >-
+    Easy to use local storage management.
+  license:
+    module:
+    - MIT
+    content:
+    - MPLv2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/stratis.git?#9b532650b3aa46f31e204f9e592f77092b39d84c
+      commit: 9b532650b3aa46f31e204f9e592f77092b39d84c
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        stratisd:
+          ref: fdbba2c34c470cc375c439c92a5d88093a6c5a5b
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: []
+  references:
+    community: https://github.com/stratis-storage
+    documentation: https://stratis-storage.github.io
+    tracker: https://github.com/stratis-storage/stratisd/issues
+  profiles:
+    default:
+      rpms:
+      - stratis-cli
+      - stratisd
+  api:
+    rpms:
+    - stratisd
+  components:
+    rpms:
+      stratisd:
+        rationale: 'Daemon that manages a pool of block devices to create flexible
+          filesystems.
+
+
+          Main component.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/stratisd
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/stratisd
+        ref: master
+  artifacts:
+    rpms:
+    - stratisd-0:0.5.4-3.module_1955+a3f37153.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: stratis
+  stream: 1
+  version: 20180927214347
+  context: 7a127764
+  arch: x86_64
+  summary: Stratis Storage
+  description: >-
+    Easy to use local storage management.
+  license:
+    module:
+    - MIT
+    content:
+    - MPLv2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/stratis.git?#e2f5584fe1ffda30d784ffd40e2d125f66622321
+      commit: e2f5584fe1ffda30d784ffd40e2d125f66622321
+      buildrequires:
+        platform:
+          ref: f30
+          stream: f30
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        stratisd:
+          ref: 2a2c3a1257da7bbd78aaeebf91776fcf79782b6f
+  dependencies:
+  - buildrequires:
+      platform: [f30]
+    requires:
+      platform: [f29]
+  references:
+    community: https://github.com/stratis-storage
+    documentation: https://stratis-storage.github.io
+    tracker: https://github.com/stratis-storage/stratisd/issues
+  profiles:
+    default:
+      rpms:
+      - stratis-cli
+      - stratisd
+  api:
+    rpms:
+    - stratisd
+  components:
+    rpms:
+      stratisd:
+        rationale: 'Daemon that manages a pool of block devices to create flexible
+          filesystems.
+
+
+          Main component.
+
+'
+        repository: git+https://src.fedoraproject.org/rpms/stratisd
+        cache: https://src.fedoraproject.org/repo/pkgs/stratisd
+        ref: 1
+  artifacts:
+    rpms:
+    - stratisd-0:1.0.0-1.module_2238+b7fada88.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: scala
+  stream: 2.10
+  version: 20180702155503
+  context: 819b5873
+  arch: x86_64
+  summary: A hybrid functional/object-oriented language for the JVM
+  description: >-
+    Scala is a general purpose programming language designed to express common programming
+    patterns in a concise, elegant, and type-safe way. It smoothly integrates features
+    of object-oriented and functional languages. It is also fully interoperable with
+    Java.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+    - ASL 2.0 and EPL and BSD
+    - BSD
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/scala.git?#90dc1eed8ec4fbf279c20f5f4ec59d01efc2890a
+      commit: 90dc1eed8ec4fbf279c20f5f4ec59d01efc2890a
+      buildrequires:
+        javapackages-tools:
+          ref: 1e429a4d686d3fdd1d93ce7e8ac7254148ea3471
+          stream: 201801
+          context: b43b0c8f
+          version: 20180629150827
+          filtered_rpms: []
+        platform:
+          ref: virtual
+          stream: f28
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        jline:
+          ref: 7b4b53826f84932425353b5ebebe2e607fa6964c
+        scala:
+          ref: da70d06a833057731e73c845aa338b1bd6d04ded
+        jansi:
+          ref: 4bdd2387b97de8352a0f7a976b7d8ccde8db0b24
+        jansi-native:
+          ref: 544b397797de885ca9b65442a4f956f817b76ddc
+        hawtjni:
+          ref: 93281e0174d79dfd549e57818292b1cbec5a7703
+  dependencies:
+  - requires:
+      platform: []
+  profiles:
+    default:
+      rpms:
+      - scala
+  api:
+    rpms:
+    - scala
+    - scala-apidoc
+    - scala-swing
+  filter:
+    rpms:
+    - ant-scala
+    - hawtjni
+    - hawtjni-javadoc
+    - jansi-javadoc
+    - jansi-native-javadoc
+    - jline-javadoc
+    - maven-hawtjni-plugin
+  buildopts:
+    rpms:
+      macros: |
+        %_with_xmvn_javadoc 1
+        %_without_asciidoc 1
+        %_without_avalon 1
+        %_without_bouncycastle 1
+        %_without_cython 1
+        %_without_dafsa 1
+        %_without_desktop 1
+        %_without_doxygen 1
+        %_without_dtd 1
+        %_without_eclipse 1
+        %_without_ehcache 1
+        %_without_emacs 1
+        %_without_equinox 1
+        %_without_fop 1
+        %_without_ftp 1
+        %_without_gradle 1
+        %_without_groovy 1
+        %_without_hadoop 1
+        %_without_hsqldb 1
+        %_without_itext 1
+        %_without_jackson 1
+        %_without_jmh 1
+        %_without_jna 1
+        %_without_jpa 1
+        %_without_junit5 1
+        %_without_logback 1
+        %_without_markdown 1
+        %_without_memcached 1
+        %_without_memoryfilesystem 1
+        %_without_obr 1
+        %_without_python 1
+        %_without_reporting 1
+        %_without_scm 1
+        %_without_snappy 1
+        %_without_spring 1
+        %_without_ssh 1
+        %_without_testlib 1
+  components:
+    rpms:
+      hawtjni:
+        rationale: 'Runtime dependency of jansi, jansi-native.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/hawtjni
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/hawtjni
+        ref: javapackages
+        buildorder: 10
+      jansi:
+        rationale: 'Runtime dependency of jline, scala.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/jansi
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/jansi
+        ref: javapackages
+        buildorder: 30
+      jansi-native:
+        rationale: 'Runtime dependency of jansi.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/jansi-native
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/jansi-native
+        ref: javapackages
+        buildorder: 20
+      jline:
+        rationale: 'Runtime dependency of scala.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/jline
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/jline
+        ref: javapackages
+        buildorder: 40
+      scala:
+        rationale: 'Module API.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/scala
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/scala
+        ref: javapackages
+        buildorder: 50
+  artifacts:
+    rpms:
+    - hawtjni-runtime-0:1.16-1.module_1889+fac7270b.noarch
+    - jansi-0:1.17.1-1.module_1889+fac7270b.noarch
+    - jansi-native-0:1.7-5.module_1889+fac7270b.x86_64
+    - jline-0:2.14.6-2.module_1889+fac7270b.noarch
+    - scala-0:2.10.6-8.module_1889+fac7270b.noarch
+    - scala-apidoc-0:2.10.6-8.module_1889+fac7270b.noarch
+    - scala-swing-0:2.10.6-8.module_1889+fac7270b.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: ripgrep
+  stream: master
+  version: 20180804140932
+  context: b33445dc
+  arch: x86_64
+  summary: Line oriented search tool using Rust's regex library
+  description: >
+    Line oriented search tool using Rust's regex library. Combines
+
+    the raw performance of grep with the usability of the silver searcher.
+  license:
+    module:
+    - MIT
+    content:
+    - Unlicense or MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/ripgrep.git?#44a146a6fc3cc5311c2dd585e66d34006e539d38
+      commit: 44a146a6fc3cc5311c2dd585e66d34006e539d38
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        rust-ripgrep:
+          ref: 844193e3738eeda66372e1016b7d1dbc2f5259ba
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: []
+  references:
+    community: https://github.com/BurntSushi/ripgrep
+    documentation: https://github.com/BurntSushi/ripgrep/blob/master/FAQ.md
+    tracker: https://github.com/BurntSushi/ripgrep/issues
+  profiles:
+    default:
+      rpms:
+      - ripgrep
+  api:
+    rpms:
+    - ripgrep
+  components:
+    rpms:
+      rust-ripgrep:
+        rationale: Main component.
+        repository: git://pkgs.fedoraproject.org/rpms/rust-ripgrep
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/rust-ripgrep
+        ref: master
+  artifacts:
+    rpms:
+    - ripgrep-0:0.9.0-1.module_1969+efa3f7be.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: reviewboard
+  stream: 3.0
+  version: 20180828143238
+  context: 083bce86
+  arch: x86_64
+  summary: A web-based code review tool
+  description: >-
+    Review Board is a powerful web-based code review tool that offers developers an
+    easy way to handle code reviews. It scales well from small projects to large companies
+    and offers a variety of tools to take much of the stress and time out of the code
+    review process.
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+    - LGPLv3
+    - MIT
+    - MIT and (MIT or GPLv2)
+    - MIT and BSD
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/reviewboard.git?#e6f3a5daedd9ff9db8b612787cea963bd4bfe5e7
+      commit: e6f3a5daedd9ff9db8b612787cea963bd4bfe5e7
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        django:
+          ref: da53d66d3db1aa5f6afd75887b00fa26849bcc0a
+          stream: 1.6
+          context: 6c81f848
+          version: 20180828135711
+          filtered_rpms: []
+      rpms:
+        ReviewBoard:
+          ref: 5df2608020e4d3bb2fd0474178a59e496e6d070f
+        python-django-cors-headers:
+          ref: 1c0762b2af97e2ddaef3e1847fdb06d950e61ff3
+        python-django-braces:
+          ref: 172667f02de94fec7cc7c3d64e6c86c2c9e9f41c
+        python-oauthlib:
+          ref: 74c26e26899c3217d93f72ae7e0ccde0053dc5f0
+        python-django-multiselectfield:
+          ref: 149bf58875fb7b55efe29e1735baf96d44eb99a9
+        python-django-haystack:
+          ref: 20fe71a6fc50a83b24578fbaf86e94a4ca584d31
+        python-django-oauth-toolkit:
+          ref: 2bbcf8bcefef32936d4e36e9468280bf99ea8532
+        python-django-evolution:
+          ref: 512424e1fc4b99f6f74c01a4130a4d9402b56b4e
+        python-asana:
+          ref: e8395e75464604bbf4ebe55a0ee3074aafa8ca2a
+        python-djblets:
+          ref: 1bc612af932bc1462a44dadbbedf24eee386e76e
+        python-django-pipeline:
+          ref: 92809ad85daf2270bb6d192adc3106fb1089cc60
+        python-pymdown-extensions:
+          ref: 78a87635b426ca7e8c6f608a38789e82b5611dc9
+  dependencies:
+  - buildrequires:
+      django: [1.6]
+      platform: [f29]
+    requires:
+      django: [1.6]
+      platform: [f29]
+  references:
+    community: https://www.reviewboard.org
+    documentation: https://www.reviewboard.org/docs
+    tracker: https://hellosplat.com/s/beanbag/tickets/
+  profiles:
+    default:
+      rpms:
+      - ReviewBoard
+    server:
+      rpms:
+      - ReviewBoard
+  api:
+    rpms:
+    - ReviewBoard
+    - python2-djblets
+  components:
+    rpms:
+      ReviewBoard:
+        rationale: The Review Board code review tool
+        repository: git+https://src.fedoraproject.org/rpms/ReviewBoard
+        cache: https://src.fedoraproject.org/repo/pkgs/ReviewBoard
+        ref: 3.0
+        buildorder: 20
+      python-asana:
+        rationale: Required by ReviewBoard to interact with Asana
+        repository: git+https://src.fedoraproject.org/rpms/python-asana
+        cache: https://src.fedoraproject.org/repo/pkgs/python-asana
+        ref: 0.7
+      python-django-braces:
+        rationale: Required by django-oauth-toolkit
+        repository: git+https://src.fedoraproject.org/rpms/python-django-braces
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-braces
+        ref: 1
+      python-django-cors-headers:
+        rationale: Required by ReviewBoard
+        repository: git+https://src.fedoraproject.org/rpms/python-django-cors-headers
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-cors-headers
+        ref: 1.1
+      python-django-evolution:
+        rationale: A database modification library used and maintained by the Review
+          Board upstream
+        repository: git+https://src.fedoraproject.org/rpms/python-django-evolution
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-evolution
+        ref: 0.7
+      python-django-haystack:
+        rationale: An older version of the Haystack search library for Django, needed
+          for compatibility.
+        repository: git+https://src.fedoraproject.org/rpms/python-django-haystack
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-haystack
+        ref: 2.4
+      python-django-multiselectfield:
+        rationale: An older version of a mult-select form field needed by Review Board.
+        repository: git+https://src.fedoraproject.org/rpms/python-django-multiselectfield
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-multiselectfield
+        ref: 0.1
+      python-django-oauth-toolkit:
+        rationale: Required by ReviewBoard for OAuth2 support
+        repository: git+https://src.fedoraproject.org/rpms/python-django-oauth-toolkit
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-oauth-toolkit
+        ref: 0.9
+        buildorder: 10
+      python-django-pipeline:
+        rationale: An older version of this asset-packaging library for Django that
+          is compatible with Review Board.
+        repository: git+https://src.fedoraproject.org/rpms/python-django-pipeline
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-pipeline
+        ref: 1.6
+      python-djblets:
+        rationale: Review Board tool library
+        repository: git+https://src.fedoraproject.org/rpms/python-djblets
+        cache: https://src.fedoraproject.org/repo/pkgs/python-djblets
+        ref: 1.0
+        buildorder: 10
+      python-oauthlib:
+        rationale: Required by django-oauth-toolkit
+        repository: git+https://src.fedoraproject.org/rpms/python-oauthlib
+        cache: https://src.fedoraproject.org/repo/pkgs/python-oauthlib
+        ref: 1.0
+      python-pymdown-extensions:
+        rationale: Required by ReviewBoard for Markdown support
+        repository: git+https://src.fedoraproject.org/rpms/python-pymdown-extensions
+        cache: https://src.fedoraproject.org/repo/pkgs/python-pymdown-extensions
+        ref: 3
+  artifacts:
+    rpms:
+    - ReviewBoard-0:3.0.8-1.module_2082+1fa91c5a.noarch
+    - python-django-haystack-docs-0:2.4.1-12.module_1655+c1bb0ce4.noarch
+    - python2-asana-0:0.7.0-3.module_2082+1fa91c5a.noarch
+    - python2-django-braces-0:1.12.0-3.module_1655+c1bb0ce4.noarch
+    - python2-django-cors-headers-0:1.1.0-1.module_1655+c1bb0ce4.noarch
+    - python2-django-evolution-1:0.7.7-12.module_1655+c1bb0ce4.noarch
+    - python2-django-haystack-0:2.4.1-12.module_1655+c1bb0ce4.noarch
+    - python2-django-multiselectfield-0:0.1.3-10.module_1655+c1bb0ce4.noarch
+    - python2-django-oauth-toolkit-0:0.9.0-3.module_1655+c1bb0ce4.noarch
+    - python2-django-pipeline-0:1.6.14-2.module_2082+1fa91c5a.noarch
+    - python2-djblets-0:1.0.6-1.module_1839+6b846779.noarch
+    - python2-oauthlib-0:1.0.3-5.module_1655+c1bb0ce4.noarch
+    - python2-pymdown-extensions-0:3.5-5.module_1655+c1bb0ce4.noarch
+    - python3-django-cors-headers-0:1.1.0-1.module_1655+c1bb0ce4.noarch
+    - python3-oauthlib-0:1.0.3-5.module_1655+c1bb0ce4.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: reviewboard
+  stream: 2.5
+  version: 20180828143308
+  context: 083bce86
+  arch: x86_64
+  summary: A web-based code review tool
+  description: >-
+    Review Board is a powerful web-based code review tool that offers developers an
+    easy way to handle code reviews. It scales well from small projects to large companies
+    and offers a variety of tools to take much of the stress and time out of the code
+    review process.
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+    - LGPLv3
+    - MIT
+    - MIT and (MIT or GPLv2)
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/reviewboard.git?#0fc31243aa85666e4e584aebda7a74e430cd0698
+      commit: 0fc31243aa85666e4e584aebda7a74e430cd0698
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        django:
+          ref: da53d66d3db1aa5f6afd75887b00fa26849bcc0a
+          stream: 1.6
+          context: 6c81f848
+          version: 20180828135711
+          filtered_rpms: []
+      rpms:
+        python-django-multiselectfield:
+          ref: 149bf58875fb7b55efe29e1735baf96d44eb99a9
+        python-markdown:
+          ref: 96c1b2f925c2ad3b7aae04ab7ebf25ae1d714ebf
+        python-django-evolution:
+          ref: 512424e1fc4b99f6f74c01a4130a4d9402b56b4e
+        python-django-pipeline:
+          ref: f019137be96cf86f49a81001fef47a0c7ab6aa35
+        ReviewBoard:
+          ref: 5d28213f6a797e5ce28ad05ab23f80fe67353da8
+        python-djblets:
+          ref: d5634779089456ff3d0ac7b78eec81e13ff4c733
+        python-django-haystack:
+          ref: 20fe71a6fc50a83b24578fbaf86e94a4ca584d31
+  dependencies:
+  - buildrequires:
+      django: [1.6]
+      platform: [f29]
+    requires:
+      django: [1.6]
+      platform: [f29]
+  references:
+    community: https://www.reviewboard.org
+    documentation: https://www.reviewboard.org/docs
+    tracker: https://hellosplat.com/s/beanbag/tickets/
+  profiles:
+    default:
+      rpms:
+      - ReviewBoard
+    server:
+      rpms:
+      - ReviewBoard
+  api:
+    rpms:
+    - ReviewBoard
+    - python2-djblets
+  components:
+    rpms:
+      ReviewBoard:
+        rationale: The Review Board code review tool
+        repository: git+https://src.fedoraproject.org/rpms/ReviewBoard
+        cache: https://src.fedoraproject.org/repo/pkgs/ReviewBoard
+        ref: 2.5
+        buildorder: 20
+      python-django-evolution:
+        rationale: A database modification library used and maintained by the Review
+          Board upstream
+        repository: git+https://src.fedoraproject.org/rpms/python-django-evolution
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-evolution
+        ref: 0.7
+      python-django-haystack:
+        rationale: An older version of the Haystack search library for Django, needed
+          for compatibility.
+        repository: git+https://src.fedoraproject.org/rpms/python-django-haystack
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-haystack
+        ref: 2.4
+      python-django-multiselectfield:
+        rationale: An older version of a mult-select form field needed by Review Board.
+        repository: git+https://src.fedoraproject.org/rpms/python-django-multiselectfield
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-multiselectfield
+        ref: 0.1
+      python-django-pipeline:
+        rationale: An older version of this asset-packaging library for Django that
+          is compatible with Review Board.
+        repository: git+https://src.fedoraproject.org/rpms/python-django-pipeline
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django-pipeline
+        ref: 1.3
+      python-djblets:
+        rationale: Review Board tool library
+        repository: git+https://src.fedoraproject.org/rpms/python-djblets
+        cache: https://src.fedoraproject.org/repo/pkgs/python-djblets
+        ref: 0.9
+        buildorder: 10
+      python-markdown:
+        rationale: An older version of this Markdown implementation that is compatible
+          with Review Board.
+        repository: git+https://src.fedoraproject.org/rpms/python-markdown
+        cache: https://src.fedoraproject.org/repo/pkgs/python-markdown
+        ref: 2.4
+  artifacts:
+    rpms:
+    - ReviewBoard-0:2.5.17-17.module_1631+4353a891.noarch
+    - python-django-haystack-docs-0:2.4.1-12.module_1631+4353a891.noarch
+    - python2-django-evolution-1:0.7.7-12.module_1631+4353a891.noarch
+    - python2-django-haystack-0:2.4.1-12.module_1631+4353a891.noarch
+    - python2-django-multiselectfield-0:0.1.3-10.module_1631+4353a891.noarch
+    - python2-django-pipeline-0:1.3.27-11.module_1631+4353a891.noarch
+    - python2-djblets-0:0.9.9-13.module_1631+4353a891.noarch
+    - python2-markdown-0:2.4.1-12.module_2085+40241970.noarch
+    - python3-markdown-0:2.4.1-12.module_2085+40241970.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: postgresql
+  stream: 9.6
+  version: 20180816142114
+  context: 6c81f848
+  arch: x86_64
+  summary: PostgreSQL module
+  description: >-
+    PostgreSQL is an advanced Object-Relational database management system (DBMS).
+    The PostgreSQL server can be found in the postgresql-server sub-package.
+  license:
+    module:
+    - MIT
+    content:
+    - PostgreSQL
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/postgresql.git?#8765a18f16976cfe6122319e337c27e9ec40206a
+      commit: 8765a18f16976cfe6122319e337c27e9ec40206a
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        postgresql:
+          ref: 3f21ecc4af44639c7cb40244f5db7a48936e3452
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://www.postgresql.org/docs/
+    tracker: https://github.com/modularity-modules/postgresql
+  profiles:
+    client:
+      rpms:
+      - postgresql
+    default:
+      rpms:
+      - postgresql-server
+    server:
+      rpms:
+      - postgresql-server
+  api:
+    rpms:
+    - postgresql
+    - postgresql-server
+  buildopts:
+    rpms:
+      macros: |
+        %runselftest 0
+  components:
+    rpms:
+      postgresql:
+        rationale: main server component
+        repository: git://pkgs.fedoraproject.org/rpms/postgresql
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/postgresql
+        ref: 3f21ecc4
+  artifacts:
+    rpms:
+    - postgresql-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-contrib-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-devel-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-docs-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-libs-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-plperl-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-plpython-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-plpython3-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-pltcl-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-server-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-static-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-test-0:9.6.8-1.module_1710+b535a823.x86_64
+    - postgresql-upgrade-0:9.6.8-1.module_1710+b535a823.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: pki
+  stream: 10.6
+  version: 20180816141946
+  context: 6c81f848
+  arch: x86_64
+  summary: Dogtag PKI
+  description: >-
+    A module for Dogtag PKI.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2 and LGPLv2
+    - LGPLv2+
+    - MPLv1.1 or GPLv2+ or LGPLv2+
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/pki.git?#ae3c166e41f4a0c896667f2c4949c8b923421625
+      commit: ae3c166e41f4a0c896667f2c4949c8b923421625
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        pki-core:
+          ref: 55207954907bfc90c746358248d21d7f21f5362c
+        jss:
+          ref: cb35c90824e12860c131a565ca18fcaacfbce156
+        tomcatjss:
+          ref: 7487d4dca363dd965ba35c8732fa86c65c69f1aa
+        dogtag-pki:
+          ref: 8c9a1c4bdb4ef13a3df0a173adfecc102a28c89b
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://www.dogtagpki.org
+    documentation: http://www.dogtagpki.org
+    tracker: https://pagure.io/dogtagpki/issues
+  profiles:
+    default:
+      rpms:
+      - dogtag-pki
+  components:
+    rpms:
+      dogtag-pki:
+        rationale: Dogtag PKI packages
+        repository: git://pkgs.fedoraproject.org/rpms/dogtag-pki
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/dogtag-pki
+        ref: 10.6
+        buildorder: 20
+      jss:
+        rationale: JSS packages
+        repository: git://pkgs.fedoraproject.org/rpms/jss
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/jss
+        ref: 4.5
+      pki-core:
+        rationale: PKI Core packages
+        repository: git://pkgs.fedoraproject.org/rpms/pki-core
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/pki-core
+        ref: 10.6
+        buildorder: 20
+      tomcatjss:
+        rationale: TomcatJSS packages
+        repository: git://pkgs.fedoraproject.org/rpms/tomcatjss
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/tomcatjss
+        ref: 7.3
+        buildorder: 10
+  artifacts:
+    rpms:
+    - dogtag-pki-0:10.6.3-1.module_1909+cebfdf1a.x86_64
+    - dogtag-pki-console-theme-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - dogtag-pki-server-theme-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - jss-0:4.5.0-0.4.module_1913+819762cf.x86_64
+    - jss-javadoc-0:4.5.0-0.4.module_1913+819762cf.x86_64
+    - pki-base-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-base-java-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-ca-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-console-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-javadoc-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-kra-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-ocsp-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-server-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-symkey-0:10.6.3-1.module_1909+cebfdf1a.x86_64
+    - pki-tks-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - pki-tools-0:10.6.3-1.module_1909+cebfdf1a.x86_64
+    - pki-tps-0:10.6.3-1.module_1909+cebfdf1a.x86_64
+    - python3-pki-0:10.6.3-1.module_1909+cebfdf1a.noarch
+    - tomcatjss-0:7.3.2-1.module_1913+819762cf.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: perl-bootstrap
+  stream: 5.26
+  version: 20180816141919
+  context: 6c81f848
+  arch: x86_64
+  summary: Perl bootstrap module for bootrapping Perl module
+  description: >
+    This is the Perl interpreter and a set of modules written in Perl language intended
+    for bootstrapping the perl module. This module disables some optional tests to
+    limit amount of components. This module is not intended for public use. It's an
+    intermediate step for building perl module.
+  license:
+    module:
+    - MIT
+    content:
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic) and BSD and Public Domain and UCD
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic) and MIT
+    - (GPL+ or Artistic) and Artistic
+    - (GPL+ or Artistic) and Artistic 2.0
+    - (GPL+ or Artistic) and Artistic 2.0 and UCD
+    - (GPL+ or Artistic) and BSD
+    - (GPL+ or Artistic) and CC0 and Public Domain
+    - (GPL+ or Artistic) and FSFAP
+    - (GPL+ or Artistic) and HSRL and MIT and UCD
+    - (GPL+ or Artistic) and MIT
+    - (GPL+ or Artistic) and Public Domain
+    - (GPL+ or Artistic) and UCD
+    - (GPL+ or Artistic) and Unicode
+    - (GPL+ or Artistic) and zlib
+    - (LGPLv2 or Artistic 2.0) and (GPL+ or Artistic)
+    - ASL 2.0
+    - Artistic 2.0
+    - BSD
+    - GPL+
+    - GPL+ or Artistic
+    - GPLv2+ or Artistic
+    - GPLv2+ or Artistic 2.0
+    - GPLv3+
+    - LGPLv2+
+    - MIT
+    - TTWL
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/perl-bootstrap.git?#ea11aea44aca54021cb782f1e243ff03722f86a5
+      commit: ea11aea44aca54021cb782f1e243ff03722f86a5
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        perl-Devel-Symdump:
+          ref: 777175a55451fddc85329a437c755efd410264da
+        perl-Test-Pod:
+          ref: b4f74114b955cfee96c10b0f04444ae6b4d2f4ce
+        perl-File-Which:
+          ref: 0c9cbe3a1d01d42035314f8d5527e6f505142cab
+        perl-Test-Needs:
+          ref: 2b9911794ccae86c53d0e4c6013fcb961e67f250
+        perl-Digest-MD5:
+          ref: 8fad912c493bc960566e5ce7118e0cdce3b9a769
+        perl-Perl-Version:
+          ref: 3d5649c15b5a2501e0e1ca057129ed3cb6166d65
+        perl-Pod-Escapes:
+          ref: b86907d1d42dbd25c327e34b09b061f0a3f96d8a
+        perl-Text-ParseWords:
+          ref: 809c9bd7181b286d5e14e80a73f6ea50ac3b62b3
+        perl-IO-Socket-INET6:
+          ref: f750541d79d2f642a06b52e6803f9c1cf81e70bf
+        perl-podlators:
+          ref: f3046951a9e1a70ccf2215f31e74c0accecd9770
+        perl-Pod-Eventual:
+          ref: 9a1fa2670ce5ae1fa9730625bc5eb657ba0b1d5b
+        perl-IPC-Cmd:
+          ref: a22c9a02e64eaca7d7ebd7326ddc2baece702cd4
+        perl-Test-Output:
+          ref: ccffd17b4ddd2bf2f739889e7b603f3071bccb97
+        perl-SUPER:
+          ref: a5b2533172574285c2ea051300f06357982e2ea9
+        perl-MRO-Compat:
+          ref: 7b9d4772b76353d755f44acc9a686e9566a1a4b7
+        perl-IPC-SysV:
+          ref: 4cf56fbde1b8a369fb6114d0f2dc7866dd835b71
+        perl-Package-Generator:
+          ref: 8a4118f2e4299109b3a7e6e0dea5ee7424e632bf
+        perl-IO-HTML:
+          ref: cf5155257c1a690461c0a0d54fa7af196b45898c
+        perl-Time-Local:
+          ref: ad2b9372902fb6279ca783752d56632d54e263b5
+        perl-Compress-Raw-Bzip2:
+          ref: 2a51171531415b788d4bc6cdd05a823fb4b831b5
+        perl-IO-String:
+          ref: b99e305978ee5a51efefa31c50ba2a0e502a71cc
+        perl:
+          ref: 8a371bbe29d1908077211d14e9e701b836c81540
+        perl-File-Slurp-Tiny:
+          ref: fbf489950350c0fc8d7a3cb883820993e7df457b
+        perl-Params-Util:
+          ref: a69abfa9df18bb76b6ccb98caa103795abc5d083
+        perl-File-Path:
+          ref: ac6856f118e7aa9a3a709c6202ab06494ecdd9b3
+        perl-Sub-Uplevel:
+          ref: 865c6011e62e5b0b8a16ce433b0ce7618d62e9a2
+        perl-Module-Load:
+          ref: 4f363f0c7d356591f33a22a930f4501167b01053
+        perl-CPAN-Meta-Requirements:
+          ref: f25cbf2508f08dcb618b5e097cda6023aea94101
+        perl-Test-CPAN-Meta:
+          ref: e495a7b866c6c955fdc577ae3408bdf2f7d4c7e6
+        perl-IO-Socket-IP:
+          ref: 1a65c1170f6582ad9ece8fe9c76c540e18cd3264
+        perl-Test-Harness:
+          ref: 65288c532917fea41328a20520e0755f6eb18463
+        perl-parent:
+          ref: c3649d1868f869883423867076131c1604fd4467
+        perl-ExtUtils-CBuilder:
+          ref: 4e5e482495a977c28396e2d1149def8dcb12e15f
+        perl-perlfaq:
+          ref: d5a90bd6871ae7a66cd64494b37727986b6eccbf
+        perl-Sub-Install:
+          ref: f3365c2a0b610eb21f6c1c786958c0e8ba08a47c
+        perl-IPC-System-Simple:
+          ref: 5b4319c5aabf7945208163c339c112b68b40d36a
+        perl-Socket:
+          ref: 20b784e3737e5842c973bd31f1735b67e77b050f
+        perl-Perl-OSType:
+          ref: 7191911473475122ff950ed36748133d8b2f968b
+        perl-ExtUtils-ParseXS:
+          ref: c84346769c6a5009890661786a061af1e06d32dd
+        perl-Test-Deep:
+          ref: 625b3e04a145219386254fde3ee2b5b3cc314567
+        perl-IPC-Run:
+          ref: 1de5fa3ae2b8d01f5e7d8f41c55dd81989176b0b
+        perl-Import-Into:
+          ref: 6abf828544edc542b88bf9f8c27886e0c4db3ab7
+        perl-ExtUtils-Install:
+          ref: 5eb9021663b033a695802e5d960795c1b338f1d1
+        perl-BSD-Resource:
+          ref: 73ae1d113bdb6c8ada065344912685ca438cc987
+        perl-autodie:
+          ref: 08926569224919ffa066397ca80c5b1818a89e90
+        perl-Locale-Maketext:
+          ref: 6dd172c644c44c07b1613b0870a119ee5e6d4116
+        perl-Test-Warnings:
+          ref: 1fb68d7818c1340f1b3d83e40bdf8556252d6e8a
+        perl-Module-Runtime:
+          ref: 47cdddc1405a658f52bd3e49321fccb776bbdfd0
+        perl-Data-OptList:
+          ref: 55696a188230a0b16e32bc0cc6183cc0683753e3
+        perl-LWP-MediaTypes:
+          ref: 5b66591ed99089c03052cd17d43fe48947e79fd1
+        perl-CPAN-Meta-YAML:
+          ref: 04a0e2e11487241ed251223755f1abe43bbe392a
+        perl-Math-BigInt-FastCalc:
+          ref: fd294a4d494055cd4f3f7e22f0f0c361162dedfa
+        perl-File-Temp:
+          ref: ac22a248d28a1f81c99b73a7a6eaa5773f98c419
+        perl-JSON-PP:
+          ref: 02d427bafed752ddfd755e1cfcd71c4daaa7b336
+        perl-Test-Simple:
+          ref: 96c4c3b6c0172748a9a9c95fb2c1fefc9f73ee04
+        perl-File-Find-Object:
+          ref: 0a1402388468fdd180b1b0875a6d9949cca924cc
+        perl-Capture-Tiny:
+          ref: 243ed7f00a6dea11dbdcb564f698573288e3e967
+        perl-HTTP-Message:
+          ref: 363ac19afb23d8e519db09bad96ed8e19f93e45a
+        perl-Pod-Coverage-TrustPod:
+          ref: 7b67d6d5912228964a685e53a9076b568cbcfa2a
+        perl-inc-latest:
+          ref: b94b9e6f144d6ce856e827a2cb9c16c42cce56b5
+        perl-Module-Build:
+          ref: a9f6bbfbfc8303db7b57cbea35e53de61a46a165
+        perl-Module-Load-Conditional:
+          ref: 532fb21fdf6ff39b29abaccbdc4a1f87941521f2
+        perl-Filter:
+          ref: 78296ad909c75c445e4c43526e3ae57f25de7c34
+        perl-Pod-Checker:
+          ref: dd7b179ffb95412b1f28d3b825d87132f391821e
+        perl-Sort-Versions:
+          ref: fdc05a617f83b5f46838821619843d5fbf563ab2
+        perl-Thread-Queue:
+          ref: 388cd4478b7d3e8ef552292fa77937aee27e9c0e
+        perl-IO-Compress:
+          ref: bb10d2103bf534e10a4a1d1bc987a4314cb5de48
+        perl-Math-BigInt:
+          ref: 76c86fadeda569a2ebd6439f12e7f69f74c8df67
+        perl-File-Find-Rule:
+          ref: 008055e020aa78373cb53e2925821fed986d32be
+        perl-Text-Template:
+          ref: c3ff74620de07ec5a20b398981cfe60bc23b7533
+        perl-Test-Exception:
+          ref: 3fe9c62023b87199f3d296242d6656cdbcbada6d
+        perl-Unicode-Normalize:
+          ref: c7a4b3f134e101eb452b949eeda6497d6ea9e520
+        perl-HTML-Tagset:
+          ref: 7cfcf4bcca6272bfa3d1bac71703acd696d78f1b
+        perl-URI:
+          ref: 8696c54987665ac968cb66d98b69e49a37a89b52
+        perl-Test-Version:
+          ref: 1032b0ab580387f8781aec3d73408514cda3460c
+        perl-Text-Glob:
+          ref: b19ed6fe9d0ff70870939d2bfe33e2bd059b732a
+        perl-Pod-Simple:
+          ref: 05a654f26321267554e75398eb19f704b4b97e17
+        perl-Algorithm-Diff:
+          ref: b572ed3bbdd7421c4ec31da90602f12f7a8c951c
+        perl-Class-XSAccessor:
+          ref: 4deb91539b2ec953c6535fb3baceda3b15a60b76
+        perl-Digest:
+          ref: b3f866352aea430935df7f2f0afaaf3cced7d214
+        perl-Test-FailWarnings:
+          ref: 1183728f2daf4a869e335bb0f79d63ff0adc7163
+        perl-Tie-IxHash:
+          ref: 483692cdeeffae0e302d06287044cc6dd356230d
+        perl-ExtUtils-MakeMaker:
+          ref: c88d4cf08d3e3ddc8c113a430d287a830c1133e6
+        perl-Compress-Raw-Zlib:
+          ref: c9d37e07af93fe0a5e4886536b27f016260074ca
+        perl-Devel-StackTrace:
+          ref: 953656c854cc43a45ef690a55978a62464019803
+        perl-ExtUtils-Manifest:
+          ref: f1169d7bb27bfb1b2db567be1f0ff112a9069246
+        perl-Pod-Parser:
+          ref: 13b1e60337a84241ed263e3a62af46005bec3b8c
+        perl-Exporter:
+          ref: 68f93042fb090750ccc7022bd957fa12ff184ecb
+        perl-MIME-Base64:
+          ref: c099afc6b1d7eec124f46bea88b86a2edd0f7b56
+        perl-version:
+          ref: ef428f4f5c736e1c3af8343191aad3fd8f288692
+        perl-experimental:
+          ref: f6265c90e007af2ae3882852d66e41c4f0294530
+        perl-CPAN:
+          ref: c91f221d2bbde2992152786a94b3da8899d7a628
+        perl-Text-Balanced:
+          ref: 8c14f0f727543b80dc9cacba0422bcc1653d0290
+        perl-PathTools:
+          ref: a0ed8e15339741624d99094a261ecef2f2bef816
+        perl-Compress-Bzip2:
+          ref: 4ca6f6001d529639ad9af34f6a4829371ed7c88c
+        perl-Number-Compare:
+          ref: 7dc6d151bfde123a33d29c4c1af0e4abafcccd00
+        perl-Fedora-VSP:
+          ref: 90425acf3b0601d4feb86e0339f0c0efdd0435ae
+        perl-Test-NoWarnings:
+          ref: 68965e00ff2d48d2a31182cd6ca4032e6e246c98
+        perl-Locale-Codes:
+          ref: e1436faa7dcf2c0cb70ead02bfbdca7fcbf7b531
+        perl-Module-CoreList:
+          ref: 3a48c78df9faa9efb5b12f33d1d3c067f4321a8a
+        perl-Scalar-List-Utils:
+          ref: c0ea69a001e7bb2a50a9c122dcc5ce792125f6e4
+        perl-Digest-SHA:
+          ref: a854293a4d31671e043e58f1efcd3848c05051c5
+        perl-CPAN-Meta-Check:
+          ref: 08fa92e0015579217acb945950b5513883a7a3e5
+        perl-Expect:
+          ref: 47e40dd9b1ecfb0a5910e6b041380568b23bb10b
+        perl-TimeDate:
+          ref: 323459d241244ac7f1de7e8a3eda452fdaf91c63
+        perl-Pod-Coverage:
+          ref: 3155ccedc6d02a815b2a5201be75f6a3a9bd8157
+        perl-generators:
+          ref: 3517fe526a3f0bb16c097eecd05bfe9dfb94c42e
+        perl-Pod-Perldoc:
+          ref: 97a96bfb531f584eaa7d70f309ca9f24699af42f
+        perl-Sub-Exporter:
+          ref: 34cd68b9ccfbae47690795a40a14a236ff0b2319
+        perl-Time-HiRes:
+          ref: 400def5c2f8c642b692a22c7a6f45da6f4cbd868
+        perl-HTTP-Tiny:
+          ref: 0353adf841dad88f6fb3d8770742b3989363c688
+        perl-Test-Taint:
+          ref: f7e00eace8747a9a77b6594648e55692180f4c42
+        perl-Text-Tabs+Wrap:
+          ref: 84d9073a2276ee2310cfc7e633c08e271c2f2319
+        perl-B-Debug:
+          ref: 5a7c0b7619476154ff3129fe449afabb1b450279
+        perl-File-HomeDir:
+          ref: 253a5f4a3d03187c799904441650124e8ec832ea
+        perl-threads:
+          ref: 96ef6a4161926a852227a37db2a82769df38ebc5
+        perl-Unicode-Collate:
+          ref: 3a0555a1c080f2bba8e052c32ce35d4c1fca429a
+        perl-Encode-Locale:
+          ref: 4a07f2dc5f13dfe03aceffeae98a4ad6cf55f8f3
+        perl-Try-Tiny:
+          ref: 844122c4abfa6248b2e8bbbf3124772c62f69525
+        perl-Text-Diff:
+          ref: 435597b4b8f23cdb4b5d08a83526f3a0ba180ba4
+        perl-threads-shared:
+          ref: 236010203776860d682ee2e6d37529e8e4aaa90a
+        perl-Math-BigRat:
+          ref: 12a221b50a7d62e76aea4bb924f502d287e86081
+        perl-HTML-Parser:
+          ref: a4851da917c159c9ec3e2a0e262a33e7b20ec333
+        perl-Storable:
+          ref: e470bb35a115fbcde8f94559e3bb9dcab0e39c97
+        perl-Getopt-Long:
+          ref: 3fcd385e78c21d29488f8e020e2b9df21c54900f
+        perl-bignum:
+          ref: e1753ef99cc972644a0a217e676467b8fd5d5788
+        perl-Net-SSLeay:
+          ref: bb304e2e37562e29cacfe38b2be1aee45553d603
+        perl-Term-ANSIColor:
+          ref: 7e942843d7f43f5535e55f7709943e210743f4fe
+        perl-IO-Tty:
+          ref: cf1db7dbd0312e7e7f47e5514d8ab31c8bba0af0
+        perl-Net-IDN-Encode:
+          ref: ab799c23d30edaa81d76e126fd771826fc7a6a3e
+        perl-Carp:
+          ref: 217d519372b989049db02455e4fd53e238bf8675
+        perl-libnet:
+          ref: 8799d71bc96c9db7a72658edcd27f9f21b260f71
+        perl-Test-TrailingSpace:
+          ref: 0c7fbdc7c25b65a32036d9e7f8af740d1d033bb8
+        perl-local-lib:
+          ref: 0716ed7be631222c11ec33672373662daa6b00bf
+        perl-Params-Check:
+          ref: 94989a67e37e22221a55b1d39dfb9f804122f928
+        perl-File-Find-Rule-Perl:
+          ref: dbda2b929804a36785ee66f4303df70d176ad1b1
+        perl-Mixin-Linewise:
+          ref: 5d8ee6f3040dde6651a61ffc0882f2dfbf605fe3
+        perl-Test-Pod-Coverage:
+          ref: f11cb72d99f17be5cb87770bbdd204c78ed750fa
+        perl-Data-Dumper:
+          ref: 8e85cc7e6166838184b034d875759a39df4d10d3
+        perl-Data-Section:
+          ref: ce79e1d99123d4220543d1eb2d2806673277cad4
+        perl-Socket6:
+          ref: 97074976ca50b6f7fd7b98a2110e24bb23cbba9b
+        perl-File-Fetch:
+          ref: 7e786fd7e77fd794553f84ff29dc777cd9f73ca2
+        perl-HTTP-Date:
+          ref: cd8b6842046370b72d530dc9aa714525d41014b3
+        perl-Software-License:
+          ref: dbee7688f08ab815650fd845122a8ee8cfb0294c
+        perl-IO-Socket-SSL:
+          ref: da2796e619b0650410425d31e1cf3659a3a8fcc5
+        perl-Archive-Tar:
+          ref: 6baa268adbe88e2afac55a5947342b7d1c2500fa
+        perl-Config-Perl-V:
+          ref: ae30cc26220da556c9fa448172710e4522fa6735
+        perl-Pod-Usage:
+          ref: 98983d9f8b961510acff3a1190c7ea62d447699f
+        perl-Env:
+          ref: 201efc08b7115ab13b1402f76ed05e5c8ed686d4
+        perl-Test-Warn:
+          ref: 90bfb89225f8505aba28f74138269a7281b03172
+        perl-Devel-Size:
+          ref: 59a39ceb2d9141d9fd9733280220395be02e83a6
+        perl-Test-MockModule:
+          ref: 8b278927b93037a9b2a93a47f68cdcfd4c090ff2
+        perl-Term-Cap:
+          ref: 1d444a86d772b87c5b0484e3639f7bac52de8afe
+        perl-Sys-Syslog:
+          ref: b83dcfb81b92c0617bee60d8ac89d1d228b88d8e
+        perl-Devel-PPPort:
+          ref: 17c87af74208a53d3202030ad52862fd376123fc
+        perl-CGI:
+          ref: 9e750f4b5aecfaf628c615831fdc30f3d396baaf
+        perl-CPAN-Meta:
+          ref: f8259dccb36b9a47dc6bad88847c3fcd3563a196
+        perl-File-Find-Object-Rule:
+          ref: 69cfed894fcb5fb7fc1b4b7d5701195285279000
+        perl-Archive-Zip:
+          ref: 09e89616f0acea510d1e85c69e12b961c28f4bb6
+        perl-DB_File:
+          ref: 462f0f70ba43c2b21811e8517b5f7c0fe2aa0ca6
+        perl-PerlIO-utf8_strict:
+          ref: 081963e3f8eb01e77546e781eceb5a68ca88fa34
+        perl-YAML:
+          ref: bc07cedbcda09b33873e03730b5d869c6f87f217
+        perl-Sub-Identify:
+          ref: b1765a68a41efd165cda6663fc9c26d2d2f44bbd
+        perl-Filter-Simple:
+          ref: 08e79709ade8905bc3212d2c7dbb1d168d578dba
+        perl-Module-Metadata:
+          ref: 1578659d3194251b91e39887baf3ad56689fad90
+        perl-Net-LibIDN:
+          ref: b62c33bc0db667bcfa1486b0bd3eaf349b295e6c
+        perl-PerlIO-via-QuotedPrint:
+          ref: 7d17de12fac09e63e1c14ed17229c6d23e923830
+        perl-constant:
+          ref: bce81fc9c982eeee92490116718ab9ed652eb0e7
+        perl-Encode:
+          ref: 5417f768a229062a55dde8f25b5b9aac039f96e1
+    mbs_options:
+      blocked_packages:
+      - perl
+      - perl-Algorithm-Diff
+      - perl-Archive-Tar
+      - perl-Archive-Zip
+      - perl-autodie
+      - perl-B-Debug
+      - perl-bignum
+      - perl-BSD-Resource
+      - perl-Capture-Tiny
+      - perl-Carp
+      - perl-CGI
+      - perl-Class-XSAccessor
+      - perl-Compress-Bzip2
+      - perl-Compress-Raw-Bzip2
+      - perl-Compress-Raw-Zlib
+      - perl-Config-Perl-V
+      - perl-constant
+      - perl-CPAN
+      - perl-CPAN-Meta
+      - perl-CPAN-Meta-Check
+      - perl-CPAN-Meta-Requirements
+      - perl-CPAN-Meta-YAML
+      - perl-Data-Dumper
+      - perl-Data-OptList
+      - perl-Data-Section
+      - perl-DB_File
+      - perl-Devel-PPPort
+      - perl-Devel-Size
+      - perl-Devel-StackTrace
+      - perl-Devel-Symdump
+      - perl-Digest
+      - perl-Digest-MD5
+      - perl-Digest-SHA
+      - perl-Encode
+      - perl-Encode-Locale
+      - perl-Env
+      - perl-Expect
+      - perl-experimental
+      - perl-Exporter
+      - perl-ExtUtils-CBuilder
+      - perl-ExtUtils-Install
+      - perl-ExtUtils-MakeMaker
+      - perl-ExtUtils-Manifest
+      - perl-ExtUtils-ParseXS
+      - perl-Fedora-VSP
+      - perl-File-Fetch
+      - perl-File-Find-Object
+      - perl-File-Find-Object-Rule
+      - perl-File-Find-Rule
+      - perl-File-Find-Rule-Perl
+      - perl-File-HomeDir
+      - perl-File-Path
+      - perl-File-Slurp-Tiny
+      - perl-File-Temp
+      - perl-File-Which
+      - perl-Filter
+      - perl-Filter-Simple
+      - perl-generators
+      - perl-Getopt-Long
+      - perl-HTML-Parser
+      - perl-HTML-Tagset
+      - perl-HTTP-Date
+      - perl-HTTP-Message
+      - perl-HTTP-Tiny
+      - perl-Import-Into
+      - perl-inc-latest
+      - perl-IO-Compress
+      - perl-IO-HTML
+      - perl-IO-Socket-INET6
+      - perl-IO-Socket-IP
+      - perl-IO-Socket-SSL
+      - perl-IO-String
+      - perl-IO-Tty
+      - perl-IPC-Cmd
+      - perl-IPC-Run
+      - perl-IPC-System-Simple
+      - perl-IPC-SysV
+      - perl-JSON-PP
+      - perl-libnet
+      - perl-local-lib
+      - perl-Locale-Codes
+      - perl-Locale-Maketext
+      - perl-LWP-MediaTypes
+      - perl-Math-BigInt
+      - perl-Math-BigInt-FastCalc
+      - perl-Math-BigRat
+      - perl-MIME-Base64
+      - perl-Mixin-Linewise
+      - perl-Module-Build
+      - perl-Module-CoreList
+      - perl-Module-Load
+      - perl-Module-Load-Conditional
+      - perl-Module-Metadata
+      - perl-Module-Runtime
+      - perl-MRO-Compat
+      - perl-Net-IDN-Encode
+      - perl-Net-LibIDN
+      - perl-Net-SSLeay
+      - perl-Number-Compare
+      - perl-Package-Generator
+      - perl-Params-Check
+      - perl-Params-Util
+      - perl-parent
+      - perl-PathTools
+      - perl-Perl-OSType
+      - perl-Perl-Version
+      - perl-perlfaq
+      - perl-PerlIO-utf8_strict
+      - perl-PerlIO-via-QuotedPrint
+      - perl-Pod-Checker
+      - perl-Pod-Coverage
+      - perl-Pod-Coverage-TrustPod
+      - perl-Pod-Escapes
+      - perl-Pod-Eventual
+      - perl-Pod-Parser
+      - perl-Pod-Perldoc
+      - perl-Pod-Simple
+      - perl-Pod-Usage
+      - perl-podlators
+      - perl-Scalar-List-Utils
+      - perl-Socket
+      - perl-Socket6
+      - perl-Software-License
+      - perl-Sort-Versions
+      - perl-Storable
+      - perl-Sub-Exporter
+      - perl-Sub-Identify
+      - perl-Sub-Install
+      - perl-Sub-Uplevel
+      - perl-SUPER
+      - perl-Sys-Syslog
+      - perl-Term-ANSIColor
+      - perl-Term-Cap
+      - perl-Test-CPAN-Meta
+      - perl-Test-Deep
+      - perl-Test-Exception
+      - perl-Test-FailWarnings
+      - perl-Test-Harness
+      - perl-Test-MockModule
+      - perl-Test-Needs
+      - perl-Test-NoWarnings
+      - perl-Test-Output
+      - perl-Test-Pod
+      - perl-Test-Pod-Coverage
+      - perl-Test-Simple
+      - perl-Test-Taint
+      - perl-Test-TrailingSpace
+      - perl-Test-Version
+      - perl-Test-Warn
+      - perl-Test-Warnings
+      - perl-Text-Balanced
+      - perl-Text-Diff
+      - perl-Text-Glob
+      - perl-Text-ParseWords
+      - perl-Text-Tabs+Wrap
+      - perl-Text-Template
+      - perl-Thread-Queue
+      - perl-threads
+      - perl-threads-shared
+      - perl-Tie-IxHash
+      - perl-Time-HiRes
+      - perl-Time-Local
+      - perl-TimeDate
+      - perl-Try-Tiny
+      - perl-Unicode-Collate
+      - perl-Unicode-Normalize
+      - perl-URI
+      - perl-version
+      - perl-YAML
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://fedoraproject.org/wiki/Modularity
+    documentation: https://fedoraproject.org/wiki/Fedora_Packaging_Guidelines_for_Modules
+  buildopts:
+    rpms:
+      macros: |
+        %perl_bootstrap 1
+        %_with_perl_enables_groff 1
+        %_without_perl_enables_syslog_test 1
+        %_with_perl_enables_systemtap 1
+        %_without_perl_enables_tcsh 1
+        %_without_perl_Compress_Bzip2_enables_optional_test 1
+        %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+        %_without_perl_IPC_System_Simple_enables_optional_test 1
+        %_without_perl_LWP_MediaTypes_enables_mailcap 1
+        %_without_perl_Module_Build_enables_optional_test 1
+        %_without_perl_Perl_OSType_enables_optional_test 1
+        %_without_perl_Pod_Perldoc_enables_tk_test 1
+        %_without_perl_Software_License_enables_optional_test 1
+        %_without_perl_Sys_Syslog_enables_optional_test 1
+        %_without_perl_Test_Harness_enables_optional_test 1
+        %_without_perl_Test_Simple_enables_optional_test 1
+        %_without_perl_Test_Warnings_enables_optional_test 1
+        %_without_perl_URI_enables_Business_ISBN 1
+  components:
+    rpms:
+      perl:
+        rationale: The Perl interpreter.
+        repository: git://pkgs.fedoraproject.org/rpms/perl
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl
+        ref: f28
+      perl-Algorithm-Diff:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Algorithm-Diff
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Algorithm-Diff
+        ref: f28
+        buildorder: 3
+      perl-Archive-Tar:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Archive-Tar
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Archive-Tar
+        ref: f28
+        buildorder: 3
+      perl-Archive-Zip:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Archive-Zip
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Archive-Zip
+        ref: f28
+        buildorder: 7
+      perl-B-Debug:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-B-Debug
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-B-Debug
+        ref: f28
+        buildorder: 3
+      perl-BSD-Resource:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-BSD-Resource
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-BSD-Resource
+        ref: f28
+        buildorder: 6
+      perl-CGI:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CGI
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CGI
+        ref: f28
+        buildorder: 12
+      perl-CPAN:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN
+        ref: f28
+        buildorder: 3
+      perl-CPAN-Meta:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta
+        ref: f28
+        buildorder: 3
+      perl-CPAN-Meta-Check:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-Check
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-Check
+        ref: f28
+        buildorder: 9
+      perl-CPAN-Meta-Requirements:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-Requirements
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-Requirements
+        ref: f28
+        buildorder: 3
+      perl-CPAN-Meta-YAML:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-YAML
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-YAML
+        ref: f28
+        buildorder: 3
+      perl-Capture-Tiny:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Capture-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Capture-Tiny
+        ref: f28
+        buildorder: 3
+      perl-Carp:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Carp
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Carp
+        ref: f28
+        buildorder: 3
+      perl-Class-XSAccessor:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Class-XSAccessor
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Class-XSAccessor
+        ref: f28
+        buildorder: 3
+      perl-Compress-Bzip2:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Bzip2
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Bzip2
+        ref: f28
+        buildorder: 3
+      perl-Compress-Raw-Bzip2:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Raw-Bzip2
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Raw-Bzip2
+        ref: f28
+        buildorder: 3
+      perl-Compress-Raw-Zlib:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Raw-Zlib
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Raw-Zlib
+        ref: f28
+        buildorder: 3
+      perl-Config-Perl-V:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Config-Perl-V
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Config-Perl-V
+        ref: f28
+        buildorder: 3
+      perl-DB_File:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-DB_File
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-DB_File
+        ref: f28
+        buildorder: 3
+      perl-Data-Dumper:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-Dumper
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-Dumper
+        ref: f28
+        buildorder: 3
+      perl-Data-OptList:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-OptList
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-OptList
+        ref: f28
+        buildorder: 4
+      perl-Data-Section:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-Section
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-Section
+        ref: f28
+        buildorder: 6
+      perl-Devel-PPPort:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-PPPort
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-PPPort
+        ref: f28
+        buildorder: 3
+      perl-Devel-Size:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-Size
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-Size
+        ref: f28
+        buildorder: 6
+      perl-Devel-StackTrace:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-StackTrace
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-StackTrace
+        ref: f28
+        buildorder: 3
+      perl-Devel-Symdump:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-Symdump
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-Symdump
+        ref: f28
+        buildorder: 3
+      perl-Digest:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest
+        ref: f28
+        buildorder: 3
+      perl-Digest-MD5:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-MD5
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-MD5
+        ref: f28
+        buildorder: 3
+      perl-Digest-SHA:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-SHA
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-SHA
+        ref: f28
+        buildorder: 3
+      perl-Encode:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Encode
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Encode
+        ref: f28
+        buildorder: 3
+      perl-Encode-Locale:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Encode-Locale
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Encode-Locale
+        ref: f28
+        buildorder: 3
+      perl-Env:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Env
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Env
+        ref: f28
+        buildorder: 3
+      perl-Expect:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Expect
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Expect
+        ref: f28
+        buildorder: 4
+      perl-Exporter:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Exporter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Exporter
+        ref: f28
+        buildorder: 3
+      perl-ExtUtils-CBuilder:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-CBuilder
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-CBuilder
+        ref: f28
+        buildorder: 3
+      perl-ExtUtils-Install:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-Install
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-Install
+        ref: f28
+        buildorder: 3
+      perl-ExtUtils-MakeMaker:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-MakeMaker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-MakeMaker
+        ref: f28
+        buildorder: 3
+      perl-ExtUtils-Manifest:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-Manifest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-Manifest
+        ref: f28
+        buildorder: 3
+      perl-ExtUtils-ParseXS:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-ParseXS
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-ParseXS
+        ref: f28
+        buildorder: 3
+      perl-Fedora-VSP:
+        rationale: RPM dependency generator.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Fedora-VSP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Fedora-VSP
+        ref: f28
+        buildorder: 1
+      perl-File-Fetch:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Fetch
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Fetch
+        ref: f28
+        buildorder: 3
+      perl-File-Find-Object:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Find-Object
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Find-Object
+        ref: f28
+        buildorder: 4
+      perl-File-Find-Object-Rule:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Find-Object-Rule
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Find-Object-Rule
+        ref: f28
+        buildorder: 5
+      perl-File-Find-Rule:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Find-Rule
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Find-Rule
+        ref: f28
+        buildorder: 4
+      perl-File-Find-Rule-Perl:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Find-Rule-Perl
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Find-Rule-Perl
+        ref: f28
+        buildorder: 5
+      perl-File-HomeDir:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-HomeDir
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-HomeDir
+        ref: f28
+        buildorder: 4
+      perl-File-Path:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Path
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Path
+        ref: f28
+        buildorder: 3
+      perl-File-Slurp-Tiny:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Slurp-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Slurp-Tiny
+        ref: f28
+        buildorder: 3
+      perl-File-Temp:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Temp
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Temp
+        ref: f28
+        buildorder: 3
+      perl-File-Which:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Which
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Which
+        ref: f28
+        buildorder: 3
+      perl-Filter:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Filter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Filter
+        ref: f28
+        buildorder: 3
+      perl-Filter-Simple:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Filter-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Filter-Simple
+        ref: f28
+        buildorder: 3
+      perl-Getopt-Long:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Getopt-Long
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Getopt-Long
+        ref: f28
+        buildorder: 3
+      perl-HTML-Parser:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTML-Parser
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTML-Parser
+        ref: f28
+        buildorder: 5
+      perl-HTML-Tagset:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTML-Tagset
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTML-Tagset
+        ref: f28
+        buildorder: 3
+      perl-HTTP-Date:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTTP-Date
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTTP-Date
+        ref: f28
+        buildorder: 3
+      perl-HTTP-Message:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTTP-Message
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTTP-Message
+        ref: f28
+        buildorder: 11
+      perl-HTTP-Tiny:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTTP-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTTP-Tiny
+        ref: f28
+        buildorder: 3
+      perl-IO-Compress:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Compress
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Compress
+        ref: f28
+        buildorder: 4
+      perl-IO-HTML:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-HTML
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-HTML
+        ref: f28
+        buildorder: 3
+      perl-IO-Socket-INET6:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Socket-INET6
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Socket-INET6
+        ref: f28
+        buildorder: 7
+      perl-IO-Socket-IP:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Socket-IP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Socket-IP
+        ref: f28
+        buildorder: 3
+      perl-IO-Socket-SSL:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Socket-SSL
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Socket-SSL
+        ref: f28
+        buildorder: 8
+      perl-IO-String:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-String
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-String
+        ref: f28
+        buildorder: 3
+      perl-IO-Tty:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Tty
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Tty
+        ref: f28
+        buildorder: 3
+      perl-IPC-Cmd:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-Cmd
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-Cmd
+        ref: f28
+        buildorder: 3
+      perl-IPC-Run:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-Run
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-Run
+        ref: f28
+        buildorder: 4
+      perl-IPC-SysV:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-SysV
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-SysV
+        ref: f28
+        buildorder: 3
+      perl-IPC-System-Simple:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-System-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-System-Simple
+        ref: f28
+        buildorder: 3
+      perl-Import-Into:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Import-Into
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Import-Into
+        ref: f28
+        buildorder: 7
+      perl-JSON-PP:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-JSON-PP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-JSON-PP
+        ref: f28
+        buildorder: 3
+      perl-LWP-MediaTypes:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-LWP-MediaTypes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-LWP-MediaTypes
+        ref: f28
+        buildorder: 3
+      perl-Locale-Codes:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Locale-Codes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Locale-Codes
+        ref: f28
+        buildorder: 3
+      perl-Locale-Maketext:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Locale-Maketext
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Locale-Maketext
+        ref: f28
+        buildorder: 3
+      perl-MIME-Base64:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-MIME-Base64
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-MIME-Base64
+        ref: f28
+        buildorder: 3
+      perl-MRO-Compat:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-MRO-Compat
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-MRO-Compat
+        ref: f28
+        buildorder: 3
+      perl-Math-BigInt:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigInt
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigInt
+        ref: f28
+        buildorder: 3
+      perl-Math-BigInt-FastCalc:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigInt-FastCalc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigInt-FastCalc
+        ref: f28
+        buildorder: 4
+      perl-Math-BigRat:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigRat
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigRat
+        ref: f28
+        buildorder: 3
+      perl-Mixin-Linewise:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Mixin-Linewise
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Mixin-Linewise
+        ref: f28
+        buildorder: 6
+      perl-Module-Build:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Build
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Build
+        ref: f28
+        buildorder: 4
+      perl-Module-CoreList:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-CoreList
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-CoreList
+        ref: f28
+        buildorder: 3
+      perl-Module-Load:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Load
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Load
+        ref: f28
+        buildorder: 3
+      perl-Module-Load-Conditional:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Load-Conditional
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Load-Conditional
+        ref: f28
+        buildorder: 3
+      perl-Module-Metadata:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Metadata
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Metadata
+        ref: f28
+        buildorder: 3
+      perl-Module-Runtime:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Runtime
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Runtime
+        ref: f28
+        buildorder: 6
+      perl-Net-IDN-Encode:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Net-IDN-Encode
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Net-IDN-Encode
+        ref: f28
+        buildorder: 5
+      perl-Net-LibIDN:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Net-LibIDN
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Net-LibIDN
+        ref: f28
+        buildorder: 3
+      perl-Net-SSLeay:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Net-SSLeay
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Net-SSLeay
+        ref: f28
+        buildorder: 5
+      perl-Number-Compare:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Number-Compare
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Number-Compare
+        ref: f28
+        buildorder: 3
+      perl-Package-Generator:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Package-Generator
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Package-Generator
+        ref: f28
+        buildorder: 4
+      perl-Params-Check:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Params-Check
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Params-Check
+        ref: f28
+        buildorder: 3
+      perl-Params-Util:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Params-Util
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Params-Util
+        ref: f28
+        buildorder: 3
+      perl-PathTools:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PathTools
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PathTools
+        ref: f28
+        buildorder: 3
+      perl-Perl-OSType:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Perl-OSType
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Perl-OSType
+        ref: f28
+        buildorder: 3
+      perl-Perl-Version:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Perl-Version
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Perl-Version
+        ref: f28
+        buildorder: 6
+      perl-PerlIO-utf8_strict:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PerlIO-utf8_strict
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PerlIO-utf8_strict
+        ref: f28
+        buildorder: 5
+      perl-PerlIO-via-QuotedPrint:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PerlIO-via-QuotedPrint
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PerlIO-via-QuotedPrint
+        ref: f28
+        buildorder: 3
+      perl-Pod-Checker:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Checker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Checker
+        ref: f28
+        buildorder: 3
+      perl-Pod-Coverage:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Coverage
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Coverage
+        ref: f28
+        buildorder: 4
+      perl-Pod-Coverage-TrustPod:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Coverage-TrustPod
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Coverage-TrustPod
+        ref: f28
+        buildorder: 8
+      perl-Pod-Escapes:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Escapes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Escapes
+        ref: f28
+        buildorder: 3
+      perl-Pod-Eventual:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Eventual
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Eventual
+        ref: f28
+        buildorder: 7
+      perl-Pod-Parser:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Parser
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Parser
+        ref: f28
+        buildorder: 3
+      perl-Pod-Perldoc:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Perldoc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Perldoc
+        ref: f28
+        buildorder: 3
+      perl-Pod-Simple:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Simple
+        ref: f28
+        buildorder: 3
+      perl-Pod-Usage:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Usage
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Usage
+        ref: f28
+        buildorder: 3
+      perl-SUPER:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-SUPER
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-SUPER
+        ref: f28
+        buildorder: 5
+      perl-Scalar-List-Utils:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Scalar-List-Utils
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Scalar-List-Utils
+        ref: f28
+        buildorder: 3
+      perl-Socket:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Socket
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Socket
+        ref: f28
+        buildorder: 3
+      perl-Socket6:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Socket6
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Socket6
+        ref: f28
+        buildorder: 3
+      perl-Software-License:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Software-License
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Software-License
+        ref: f28
+        buildorder: 11
+      perl-Sort-Versions:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sort-Versions
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sort-Versions
+        ref: f28
+        buildorder: 3
+      perl-Storable:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Storable
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Storable
+        ref: f28
+        buildorder: 3
+      perl-Sub-Exporter:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Exporter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Exporter
+        ref: f28
+        buildorder: 5
+      perl-Sub-Identify:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Identify
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Identify
+        ref: f28
+        buildorder: 4
+      perl-Sub-Install:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Install
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Install
+        ref: f28
+        buildorder: 3
+      perl-Sub-Uplevel:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Uplevel
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Uplevel
+        ref: f28
+        buildorder: 3
+      perl-Sys-Syslog:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sys-Syslog
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sys-Syslog
+        ref: f28
+        buildorder: 3
+      perl-Term-ANSIColor:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Term-ANSIColor
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Term-ANSIColor
+        ref: f28
+        buildorder: 3
+      perl-Term-Cap:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Term-Cap
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Term-Cap
+        ref: f28
+        buildorder: 3
+      perl-Test-CPAN-Meta:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-CPAN-Meta
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-CPAN-Meta
+        ref: f28
+        buildorder: 6
+      perl-Test-Deep:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Deep
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Deep
+        ref: f28
+        buildorder: 3
+      perl-Test-Exception:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Exception
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Exception
+        ref: f28
+        buildorder: 4
+      perl-Test-FailWarnings:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-FailWarnings
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-FailWarnings
+        ref: f28
+        buildorder: 4
+      perl-Test-Harness:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Harness
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Harness
+        ref: f28
+        buildorder: 3
+      perl-Test-MockModule:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-MockModule
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-MockModule
+        ref: f28
+        buildorder: 6
+      perl-Test-Needs:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Needs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Needs
+        ref: f28
+        buildorder: 3
+      perl-Test-NoWarnings:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-NoWarnings
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-NoWarnings
+        ref: f28
+        buildorder: 4
+      perl-Test-Output:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Output
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Output
+        ref: f28
+        buildorder: 6
+      perl-Test-Pod:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Pod
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Pod
+        ref: f28
+        buildorder: 3
+      perl-Test-Pod-Coverage:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Pod-Coverage
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Pod-Coverage
+        ref: f28
+        buildorder: 5
+      perl-Test-Simple:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Simple
+        ref: f28
+        buildorder: 3
+      perl-Test-Taint:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Taint
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Taint
+        ref: f28
+        buildorder: 6
+      perl-Test-TrailingSpace:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-TrailingSpace
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-TrailingSpace
+        ref: f28
+        buildorder: 6
+      perl-Test-Version:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Version
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Version
+        ref: f28
+        buildorder: 6
+      perl-Test-Warn:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Warn
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Warn
+        ref: f28
+        buildorder: 4
+      perl-Test-Warnings:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Warnings
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Warnings
+        ref: f28
+        buildorder: 3
+      perl-Text-Balanced:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Balanced
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Balanced
+        ref: f28
+        buildorder: 3
+      perl-Text-Diff:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Diff
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Diff
+        ref: f28
+        buildorder: 4
+      perl-Text-Glob:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Glob
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Glob
+        ref: f28
+        buildorder: 3
+      perl-Text-ParseWords:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-ParseWords
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-ParseWords
+        ref: f28
+        buildorder: 3
+      perl-Text-Tabs+Wrap:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Tabs+Wrap
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Tabs+Wrap
+        ref: f28
+        buildorder: 3
+      perl-Text-Template:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Template
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Template
+        ref: f28
+        buildorder: 4
+      perl-Thread-Queue:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Thread-Queue
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Thread-Queue
+        ref: f28
+        buildorder: 3
+      perl-Tie-IxHash:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Tie-IxHash
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Tie-IxHash
+        ref: f28
+        buildorder: 3
+      perl-Time-HiRes:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Time-HiRes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Time-HiRes
+        ref: f28
+        buildorder: 3
+      perl-Time-Local:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Time-Local
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Time-Local
+        ref: f28
+        buildorder: 3
+      perl-TimeDate:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-TimeDate
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-TimeDate
+        ref: f28
+        buildorder: 3
+      perl-Try-Tiny:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Try-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Try-Tiny
+        ref: f28
+        buildorder: 10
+      perl-URI:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-URI
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-URI
+        ref: f28
+        buildorder: 4
+      perl-Unicode-Collate:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Unicode-Collate
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Unicode-Collate
+        ref: f28
+        buildorder: 3
+      perl-Unicode-Normalize:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Unicode-Normalize
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Unicode-Normalize
+        ref: f28
+        buildorder: 3
+      perl-YAML:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-YAML
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-YAML
+        ref: f28
+        buildorder: 3
+      perl-autodie:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-autodie
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-autodie
+        ref: f28
+        buildorder: 3
+      perl-bignum:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-bignum
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-bignum
+        ref: f28
+        buildorder: 3
+      perl-constant:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-constant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-constant
+        ref: f28
+        buildorder: 3
+      perl-experimental:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-experimental
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-experimental
+        ref: f28
+        buildorder: 3
+      perl-generators:
+        rationale: RPM dependency generator.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-generators
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-generators
+        ref: f28
+        buildorder: 2
+      perl-inc-latest:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-inc-latest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-inc-latest
+        ref: f28
+        buildorder: 3
+      perl-libnet:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-libnet
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-libnet
+        ref: f28
+        buildorder: 3
+      perl-local-lib:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-local-lib
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-local-lib
+        ref: f28
+        buildorder: 5
+      perl-parent:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-parent
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-parent
+        ref: f28
+        buildorder: 3
+      perl-perlfaq:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-perlfaq
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-perlfaq
+        ref: f28
+        buildorder: 3
+      perl-podlators:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-podlators
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-podlators
+        ref: f28
+        buildorder: 3
+      perl-threads:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-threads
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-threads
+        ref: f28
+        buildorder: 3
+      perl-threads-shared:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-threads-shared
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-threads-shared
+        ref: f28
+        buildorder: 3
+      perl-version:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-version
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-version
+        ref: f28
+        buildorder: 3
+  artifacts:
+    rpms:
+    - perl-4:5.26.2-413.module_2073+eebc5b71.x86_64
+    - perl-Algorithm-Diff-0:1.1903-9.module_1675+7c48d950.noarch
+    - perl-Archive-Tar-0:2.24-413.module_2073+eebc5b71.noarch
+    - perl-Archive-Tar-0:2.28-1.module_2073+eebc5b71.noarch
+    - perl-Archive-Zip-0:1.60-3.module_2073+eebc5b71.noarch
+    - perl-Attribute-Handlers-0:0.99-413.module_2073+eebc5b71.noarch
+    - perl-B-Debug-0:1.24-413.module_2073+eebc5b71.noarch
+    - perl-B-Debug-0:1.26-2.module_1675+7c48d950.noarch
+    - perl-BSD-Resource-0:1.291.100-5.module_1675+7c48d950.x86_64
+    - perl-CGI-0:4.38-2.module_1675+7c48d950.noarch
+    - perl-CPAN-0:2.18-397.module_1675+7c48d950.noarch
+    - perl-CPAN-0:2.18-413.module_2073+eebc5b71.noarch
+    - perl-CPAN-Meta-0:2.150010-396.module_1675+7c48d950.noarch
+    - perl-CPAN-Meta-0:2.150010-413.module_2073+eebc5b71.noarch
+    - perl-CPAN-Meta-Check-0:0.014-5.module_1675+7c48d950.noarch
+    - perl-CPAN-Meta-Requirements-0:2.140-396.module_1675+7c48d950.noarch
+    - perl-CPAN-Meta-Requirements-0:2.140-413.module_2073+eebc5b71.noarch
+    - perl-CPAN-Meta-YAML-0:0.018-397.module_1675+7c48d950.noarch
+    - perl-CPAN-Meta-YAML-0:0.018-413.module_2073+eebc5b71.noarch
+    - perl-Capture-Tiny-0:0.46-4.module_1675+7c48d950.noarch
+    - perl-Carp-0:1.42-396.module_2073+eebc5b71.noarch
+    - perl-Carp-0:1.42-413.module_2073+eebc5b71.noarch
+    - perl-Class-XSAccessor-0:1.19-14.module_1675+7c48d950.x86_64
+    - perl-Compress-Bzip2-0:2.26-6.module_1675+7c48d950.x86_64
+    - perl-Compress-Raw-Bzip2-0:2.074-413.module_2073+eebc5b71.x86_64
+    - perl-Compress-Raw-Bzip2-0:2.081-1.module_1675+7c48d950.x86_64
+    - perl-Compress-Raw-Zlib-0:2.074-413.module_2073+eebc5b71.x86_64
+    - perl-Compress-Raw-Zlib-0:2.081-1.module_1675+7c48d950.x86_64
+    - perl-Config-Perl-V-0:0.28-413.module_2073+eebc5b71.noarch
+    - perl-Config-Perl-V-0:0.30-1.module_2073+eebc5b71.noarch
+    - perl-DB_File-0:1.840-413.module_2073+eebc5b71.x86_64
+    - perl-DB_File-0:1.842-1.module_2073+eebc5b71.x86_64
+    - perl-Data-Dumper-0:2.167-399.module_1675+7c48d950.x86_64
+    - perl-Data-Dumper-0:2.167-413.module_2073+eebc5b71.x86_64
+    - perl-Data-OptList-0:0.110-6.module_1675+7c48d950.noarch
+    - perl-Data-Section-0:0.200007-3.module_1675+7c48d950.noarch
+    - perl-Devel-PPPort-0:3.35-413.module_2073+eebc5b71.x86_64
+    - perl-Devel-PPPort-0:3.36-5.module_1675+7c48d950.x86_64
+    - perl-Devel-Peek-0:1.26-413.module_2073+eebc5b71.x86_64
+    - perl-Devel-SelfStubber-0:1.06-413.module_2073+eebc5b71.noarch
+    - perl-Devel-Size-0:0.82-1.module_2073+eebc5b71.x86_64
+    - perl-Devel-StackTrace-1:2.03-2.module_1675+7c48d950.noarch
+    - perl-Devel-Symdump-1:2.18-5.module_1675+7c48d950.noarch
+    - perl-Digest-0:1.17-395.module_1675+7c48d950.noarch
+    - perl-Digest-0:1.17-413.module_2073+eebc5b71.noarch
+    - perl-Digest-MD5-0:2.55-396.module_1675+7c48d950.x86_64
+    - perl-Digest-MD5-0:2.55-413.module_2073+eebc5b71.x86_64
+    - perl-Digest-SHA-1:5.96-413.module_2073+eebc5b71.x86_64
+    - perl-Digest-SHA-1:6.02-1.module_2073+eebc5b71.x86_64
+    - perl-Encode-4:2.88-413.module_2073+eebc5b71.x86_64
+    - perl-Encode-4:2.97-3.module_1675+7c48d950.x86_64
+    - perl-Encode-Locale-0:1.05-9.module_1675+7c48d950.noarch
+    - perl-Encode-devel-4:2.88-413.module_2073+eebc5b71.noarch
+    - perl-Encode-devel-4:2.97-3.module_1675+7c48d950.x86_64
+    - perl-Env-0:1.04-395.module_1675+7c48d950.noarch
+    - perl-Env-0:1.04-413.module_2073+eebc5b71.noarch
+    - perl-Errno-0:1.28-413.module_2073+eebc5b71.x86_64
+    - perl-Expect-0:1.35-4.module_1675+7c48d950.noarch
+    - perl-Exporter-0:5.72-396.module_1675+7c48d950.noarch
+    - perl-Exporter-0:5.72-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-CBuilder-1:0.280225-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-CBuilder-1:0.280230-2.module_1675+7c48d950.noarch
+    - perl-ExtUtils-Command-1:7.24-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-Command-1:7.34-1.module_1675+7c48d950.noarch
+    - perl-ExtUtils-Embed-0:1.34-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-Install-0:2.04-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-Install-0:2.14-4.module_1675+7c48d950.noarch
+    - perl-ExtUtils-MM-Utils-1:7.24-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-MM-Utils-1:7.34-1.module_1675+7c48d950.noarch
+    - perl-ExtUtils-MakeMaker-1:7.24-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-MakeMaker-1:7.34-1.module_1675+7c48d950.noarch
+    - perl-ExtUtils-Manifest-0:1.70-395.module_1675+7c48d950.noarch
+    - perl-ExtUtils-Manifest-0:1.70-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-Miniperl-0:1.06-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-ParseXS-1:3.34-413.module_2073+eebc5b71.noarch
+    - perl-ExtUtils-ParseXS-1:3.35-2.module_1675+7c48d950.noarch
+    - perl-Fedora-VSP-0:0.001-9.module_1675+7c48d950.noarch
+    - perl-File-Fetch-0:0.52-413.module_2073+eebc5b71.noarch
+    - perl-File-Fetch-0:0.56-2.module_1675+7c48d950.noarch
+    - perl-File-Find-Object-0:0.3.2-5.module_1675+7c48d950.noarch
+    - perl-File-Find-Object-Rule-0:0.0306-6.module_1675+7c48d950.noarch
+    - perl-File-Find-Rule-0:0.34-8.module_1675+7c48d950.noarch
+    - perl-File-Find-Rule-Perl-0:1.15-10.module_1675+7c48d950.noarch
+    - perl-File-HomeDir-0:1.002-4.module_1675+7c48d950.noarch
+    - perl-File-Path-0:2.12-413.module_2073+eebc5b71.noarch
+    - perl-File-Path-0:2.15-2.module_1675+7c48d950.noarch
+    - perl-File-Slurp-Tiny-0:0.004-7.module_1675+7c48d950.noarch
+    - perl-File-Temp-0:0.230.400-413.module_2073+eebc5b71.noarch
+    - perl-File-Temp-0:0.230.600-1.module_2073+eebc5b71.noarch
+    - perl-File-Which-0:1.22-2.module_1675+7c48d950.noarch
+    - perl-Filter-2:1.55-413.module_2073+eebc5b71.x86_64
+    - perl-Filter-2:1.58-2.module_1675+7c48d950.x86_64
+    - perl-Filter-Simple-0:0.93-413.module_2073+eebc5b71.noarch
+    - perl-Filter-Simple-0:0.94-2.module_1675+7c48d950.noarch
+    - perl-Getopt-Long-1:2.49-413.module_2073+eebc5b71.noarch
+    - perl-Getopt-Long-1:2.50-4.module_1675+7c48d950.noarch
+    - perl-HTML-Parser-0:3.72-11.module_1675+7c48d950.x86_64
+    - perl-HTML-Parser-tests-0:3.72-11.module_1675+7c48d950.x86_64
+    - perl-HTML-Tagset-0:3.20-33.module_1675+7c48d950.noarch
+    - perl-HTTP-Date-0:6.02-18.module_1675+7c48d950.noarch
+    - perl-HTTP-Message-0:6.18-1.module_2073+eebc5b71.noarch
+    - perl-HTTP-Tiny-0:0.070-413.module_2073+eebc5b71.noarch
+    - perl-HTTP-Tiny-0:0.076-1.module_2073+eebc5b71.noarch
+    - perl-IO-0:1.38-413.module_2073+eebc5b71.x86_64
+    - perl-IO-Compress-0:2.074-413.module_2073+eebc5b71.noarch
+    - perl-IO-Compress-0:2.081-1.module_1675+7c48d950.noarch
+    - perl-IO-HTML-0:1.001-10.module_1675+7c48d950.noarch
+    - perl-IO-Socket-INET6-0:2.72-12.module_1675+7c48d950.noarch
+    - perl-IO-Socket-IP-0:0.38-413.module_2073+eebc5b71.noarch
+    - perl-IO-Socket-IP-0:0.39-5.module_1675+7c48d950.noarch
+    - perl-IO-Socket-SSL-0:2.056-1.module_1675+7c48d950.noarch
+    - perl-IO-String-0:1.08-31.module_1675+7c48d950.noarch
+    - perl-IO-Tty-0:1.12-11.module_1675+7c48d950.x86_64
+    - perl-IO-Zlib-1:1.10-413.module_2073+eebc5b71.noarch
+    - perl-IPC-Cmd-2:0.96-413.module_2073+eebc5b71.noarch
+    - perl-IPC-Cmd-2:1.02-1.module_2073+eebc5b71.noarch
+    - perl-IPC-Run-0:0.99-1.module_1675+7c48d950.noarch
+    - perl-IPC-SysV-0:2.07-397.module_1675+7c48d950.x86_64
+    - perl-IPC-SysV-0:2.07-413.module_2073+eebc5b71.x86_64
+    - perl-IPC-System-Simple-0:1.25-17.module_1675+7c48d950.noarch
+    - perl-Import-Into-0:1.002005-7.module_1675+7c48d950.noarch
+    - perl-JSON-PP-1:2.27.400-413.module_2073+eebc5b71.noarch
+    - perl-JSON-PP-1:2.97.001-2.module_1675+7c48d950.noarch
+    - perl-LWP-MediaTypes-0:6.02-14.module_1675+7c48d950.noarch
+    - perl-Locale-Codes-0:3.25-413.module_2073+eebc5b71.noarch
+    - perl-Locale-Codes-0:3.57-1.module_2073+eebc5b71.noarch
+    - perl-Locale-Maketext-0:1.28-396.module_1675+7c48d950.noarch
+    - perl-Locale-Maketext-0:1.28-413.module_2073+eebc5b71.noarch
+    - perl-Locale-Maketext-Simple-1:0.21-413.module_2073+eebc5b71.noarch
+    - perl-MIME-Base64-0:3.15-396.module_1675+7c48d950.x86_64
+    - perl-MIME-Base64-0:3.15-413.module_2073+eebc5b71.x86_64
+    - perl-MRO-Compat-0:0.13-4.module_1675+7c48d950.noarch
+    - perl-Math-BigInt-1:1.9998.06-413.module_2073+eebc5b71.noarch
+    - perl-Math-BigInt-1:1.9998.11-5.module_1675+7c48d950.noarch
+    - perl-Math-BigInt-FastCalc-0:0.500.500-413.module_2073+eebc5b71.x86_64
+    - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1675+7c48d950.x86_64
+    - perl-Math-BigRat-0:0.2611-413.module_2073+eebc5b71.noarch
+    - perl-Math-BigRat-0:0.2614-1.module_2073+eebc5b71.noarch
+    - perl-Math-Complex-0:1.59-413.module_2073+eebc5b71.noarch
+    - perl-Memoize-0:1.03-413.module_2073+eebc5b71.noarch
+    - perl-Mixin-Linewise-0:0.108-9.module_1675+7c48d950.noarch
+    - perl-Module-Build-2:0.42.24-5.module_1675+7c48d950.noarch
+    - perl-Module-CoreList-1:5.20180414-413.module_2073+eebc5b71.noarch
+    - perl-Module-CoreList-1:5.20180720-1.module_2073+eebc5b71.noarch
+    - perl-Module-CoreList-tools-1:5.20180414-413.module_2073+eebc5b71.noarch
+    - perl-Module-CoreList-tools-1:5.20180720-1.module_2073+eebc5b71.noarch
+    - perl-Module-Load-1:0.32-395.module_1675+7c48d950.noarch
+    - perl-Module-Load-1:0.32-413.module_2073+eebc5b71.noarch
+    - perl-Module-Load-Conditional-0:0.68-395.module_1675+7c48d950.noarch
+    - perl-Module-Load-Conditional-0:0.68-413.module_2073+eebc5b71.noarch
+    - perl-Module-Loaded-1:0.08-413.module_2073+eebc5b71.noarch
+    - perl-Module-Metadata-0:1.000033-395.module_1675+7c48d950.noarch
+    - perl-Module-Metadata-0:1.000033-413.module_2073+eebc5b71.noarch
+    - perl-Module-Runtime-0:0.016-2.module_1675+7c48d950.noarch
+    - perl-Net-IDN-Encode-0:2.400-6.module_1675+7c48d950.x86_64
+    - perl-Net-LibIDN-0:0.12-29.module_1675+7c48d950.x86_64
+    - perl-Net-Ping-0:2.55-413.module_2073+eebc5b71.noarch
+    - perl-Net-SSLeay-0:1.85-1.module_1675+7c48d950.x86_64
+    - perl-Number-Compare-0:0.03-19.module_1675+7c48d950.noarch
+    - perl-Package-Generator-0:1.106-11.module_1675+7c48d950.noarch
+    - perl-Params-Check-1:0.38-395.module_1675+7c48d950.noarch
+    - perl-Params-Check-1:0.38-413.module_2073+eebc5b71.noarch
+    - perl-Params-Util-0:1.07-22.module_1675+7c48d950.x86_64
+    - perl-PathTools-0:3.67-413.module_2073+eebc5b71.x86_64
+    - perl-PathTools-0:3.74-1.module_1675+7c48d950.x86_64
+    - perl-Perl-OSType-0:1.010-396.module_1675+7c48d950.noarch
+    - perl-Perl-OSType-0:1.010-413.module_2073+eebc5b71.noarch
+    - perl-Perl-Version-0:1.013-9.module_1675+7c48d950.noarch
+    - perl-PerlIO-utf8_strict-0:0.007-5.module_1675+7c48d950.x86_64
+    - perl-PerlIO-via-QuotedPrint-0:0.08-395.module_1675+7c48d950.noarch
+    - perl-PerlIO-via-QuotedPrint-0:0.08-413.module_2073+eebc5b71.noarch
+    - perl-Pod-Checker-4:1.73-395.module_1675+7c48d950.noarch
+    - perl-Pod-Checker-4:1.73-413.module_2073+eebc5b71.noarch
+    - perl-Pod-Coverage-0:0.23-14.module_1675+7c48d950.noarch
+    - perl-Pod-Coverage-TrustPod-0:0.100005-1.module_1675+7c48d950.noarch
+    - perl-Pod-Escapes-1:1.07-395.module_1675+7c48d950.noarch
+    - perl-Pod-Escapes-1:1.07-413.module_2073+eebc5b71.noarch
+    - perl-Pod-Eventual-0:0.094001-9.module_1675+7c48d950.noarch
+    - perl-Pod-Html-0:1.22.02-413.module_2073+eebc5b71.noarch
+    - perl-Pod-Parser-0:1.63-396.module_1675+7c48d950.noarch
+    - perl-Pod-Parser-0:1.63-413.module_2073+eebc5b71.noarch
+    - perl-Pod-Perldoc-0:3.28-413.module_2073+eebc5b71.noarch
+    - perl-Pod-Perldoc-0:3.28.01-1.module_2073+eebc5b71.noarch
+    - perl-Pod-Simple-1:3.35-395.module_1675+7c48d950.noarch
+    - perl-Pod-Simple-1:3.35-413.module_2073+eebc5b71.noarch
+    - perl-Pod-Usage-4:1.69-395.module_1675+7c48d950.noarch
+    - perl-Pod-Usage-4:1.69-413.module_2073+eebc5b71.noarch
+    - perl-SUPER-0:1.20141117-10.module_1675+7c48d950.noarch
+    - perl-Scalar-List-Utils-3:1.46-413.module_2073+eebc5b71.x86_64
+    - perl-Scalar-List-Utils-3:1.49-2.module_1675+7c48d950.x86_64
+    - perl-SelfLoader-0:1.23-413.module_2073+eebc5b71.noarch
+    - perl-Socket-4:2.020-413.module_2073+eebc5b71.x86_64
+    - perl-Socket-4:2.027-2.module_1675+7c48d950.x86_64
+    - perl-Socket6-0:0.28-6.module_1675+7c48d950.x86_64
+    - perl-Software-License-0:0.103013-2.module_1675+7c48d950.noarch
+    - perl-Sort-Versions-0:1.62-8.module_1675+7c48d950.noarch
+    - perl-Storable-1:2.62-413.module_2073+eebc5b71.x86_64
+    - perl-Storable-1:3.11-2.module_2073+eebc5b71.x86_64
+    - perl-Sub-Exporter-0:0.987-15.module_1675+7c48d950.noarch
+    - perl-Sub-Identify-0:0.14-6.module_1675+7c48d950.x86_64
+    - perl-Sub-Install-0:0.928-14.module_1675+7c48d950.noarch
+    - perl-Sub-Uplevel-1:0.2800-4.module_1675+7c48d950.noarch
+    - perl-Sys-Syslog-0:0.35-397.module_1675+7c48d950.x86_64
+    - perl-Sys-Syslog-0:0.35-413.module_2073+eebc5b71.x86_64
+    - perl-Term-ANSIColor-0:4.06-396.module_1675+7c48d950.noarch
+    - perl-Term-ANSIColor-0:4.06-413.module_2073+eebc5b71.noarch
+    - perl-Term-Cap-0:1.17-395.module_1675+7c48d950.noarch
+    - perl-Term-Cap-0:1.17-413.module_2073+eebc5b71.noarch
+    - perl-Test-0:1.30-413.module_2073+eebc5b71.noarch
+    - perl-Test-CPAN-Meta-0:0.25-12.module_1675+7c48d950.noarch
+    - perl-Test-Deep-0:1.127-4.module_1675+7c48d950.noarch
+    - perl-Test-Exception-0:0.43-7.module_1675+7c48d950.noarch
+    - perl-Test-FailWarnings-0:0.008-12.module_1675+7c48d950.noarch
+    - perl-Test-Harness-1:3.38-413.module_2073+eebc5b71.noarch
+    - perl-Test-Harness-1:3.42-1.module_1675+7c48d950.noarch
+    - perl-Test-MockModule-0:0.13-3.module_1675+7c48d950.noarch
+    - perl-Test-Needs-0:0.002005-5.module_1675+7c48d950.noarch
+    - perl-Test-NoWarnings-0:1.04-15.module_1675+7c48d950.noarch
+    - perl-Test-Output-0:1.03.1-4.module_1675+7c48d950.noarch
+    - perl-Test-Pod-0:1.51-8.module_1675+7c48d950.noarch
+    - perl-Test-Pod-Coverage-0:1.10-10.module_1675+7c48d950.noarch
+    - perl-Test-Simple-1:1.302073-413.module_2073+eebc5b71.noarch
+    - perl-Test-Simple-1:1.302135-1.module_1675+7c48d950.noarch
+    - perl-Test-Taint-0:1.06-19.module_1675+7c48d950.x86_64
+    - perl-Test-TrailingSpace-0:0.0301-5.module_1675+7c48d950.noarch
+    - perl-Test-Version-0:2.07-1.module_1675+7c48d950.noarch
+    - perl-Test-Warn-0:0.32-5.module_1675+7c48d950.noarch
+    - perl-Test-Warnings-0:0.026-7.module_1675+7c48d950.noarch
+    - perl-Text-Balanced-0:2.03-395.module_1675+7c48d950.noarch
+    - perl-Text-Balanced-0:2.03-413.module_2073+eebc5b71.noarch
+    - perl-Text-Diff-0:1.45-2.module_1675+7c48d950.noarch
+    - perl-Text-Glob-0:0.11-4.module_1675+7c48d950.noarch
+    - perl-Text-ParseWords-0:3.30-395.module_1675+7c48d950.noarch
+    - perl-Text-ParseWords-0:3.30-413.module_2073+eebc5b71.noarch
+    - perl-Text-Tabs+Wrap-0:2013.0523-395.module_1675+7c48d950.noarch
+    - perl-Text-Tabs+Wrap-0:2013.0523-413.module_2073+eebc5b71.noarch
+    - perl-Text-Template-0:1.51-1.module_1675+7c48d950.noarch
+    - perl-Thread-Queue-0:3.12-413.module_2073+eebc5b71.noarch
+    - perl-Thread-Queue-0:3.13-1.module_2073+eebc5b71.noarch
+    - perl-Tie-IxHash-0:1.23-13.module_1675+7c48d950.noarch
+    - perl-Time-HiRes-0:1.9741-413.module_2073+eebc5b71.x86_64
+    - perl-Time-HiRes-0:1.9758-1.module_1675+7c48d950.x86_64
+    - perl-Time-Local-0:1.250-413.module_2073+eebc5b71.noarch
+    - perl-Time-Local-1:1.280-1.module_2073+eebc5b71.noarch
+    - perl-Time-Piece-0:1.31-413.module_2073+eebc5b71.x86_64
+    - perl-TimeDate-1:2.30-13.module_1675+7c48d950.noarch
+    - perl-Try-Tiny-0:0.30-2.module_1675+7c48d950.noarch
+    - perl-URI-0:1.73-2.module_1675+7c48d950.noarch
+    - perl-Unicode-Collate-0:1.19-413.module_2073+eebc5b71.x86_64
+    - perl-Unicode-Collate-0:1.25-2.module_1675+7c48d950.x86_64
+    - perl-Unicode-Normalize-0:1.25-396.module_1675+7c48d950.x86_64
+    - perl-Unicode-Normalize-0:1.25-413.module_2073+eebc5b71.x86_64
+    - perl-YAML-0:1.24-2.module_1675+7c48d950.noarch
+    - perl-autodie-0:2.29-396.module_1675+7c48d950.noarch
+    - perl-autodie-0:2.29-413.module_2073+eebc5b71.noarch
+    - perl-bignum-0:0.47-413.module_2073+eebc5b71.noarch
+    - perl-bignum-0:0.49-2.module_1675+7c48d950.noarch
+    - perl-constant-0:1.33-396.module_1675+7c48d950.noarch
+    - perl-constant-0:1.33-413.module_2073+eebc5b71.noarch
+    - perl-devel-4:5.26.2-413.module_2073+eebc5b71.x86_64
+    - perl-encoding-4:2.19-413.module_2073+eebc5b71.x86_64
+    - perl-encoding-4:2.22-3.module_1675+7c48d950.x86_64
+    - perl-experimental-0:0.016-413.module_2073+eebc5b71.noarch
+    - perl-experimental-0:0.020-1.module_2073+eebc5b71.noarch
+    - perl-generators-0:1.10-7.module_1675+7c48d950.noarch
+    - perl-homedir-0:2.000024-2.module_1675+7c48d950.noarch
+    - perl-inc-latest-2:0.500-9.module_1675+7c48d950.noarch
+    - perl-interpreter-4:5.26.2-413.module_2073+eebc5b71.x86_64
+    - perl-libnet-0:3.10-413.module_2073+eebc5b71.noarch
+    - perl-libnet-0:3.11-3.module_1675+7c48d950.noarch
+    - perl-libnetcfg-4:5.26.2-413.module_2073+eebc5b71.noarch
+    - perl-libs-4:5.26.2-413.module_2073+eebc5b71.x86_64
+    - perl-local-lib-0:2.000024-2.module_1675+7c48d950.noarch
+    - perl-macros-4:5.26.2-413.module_2073+eebc5b71.x86_64
+    - perl-open-0:1.11-413.module_2073+eebc5b71.noarch
+    - perl-parent-1:0.236-395.module_1675+7c48d950.noarch
+    - perl-parent-1:0.236-413.module_2073+eebc5b71.noarch
+    - perl-perlfaq-0:5.021011-413.module_2073+eebc5b71.noarch
+    - perl-perlfaq-0:5.20180605-1.module_2073+eebc5b71.noarch
+    - perl-podlators-0:4.09-413.module_2073+eebc5b71.noarch
+    - perl-podlators-0:4.11-1.module_2073+eebc5b71.noarch
+    - perl-tests-4:5.26.2-413.module_2073+eebc5b71.x86_64
+    - perl-threads-1:2.15-413.module_2073+eebc5b71.x86_64
+    - perl-threads-1:2.21-2.module_1675+7c48d950.x86_64
+    - perl-threads-shared-0:1.56-413.module_2073+eebc5b71.x86_64
+    - perl-threads-shared-0:1.58-2.module_1675+7c48d950.x86_64
+    - perl-utils-0:5.26.2-413.module_2073+eebc5b71.noarch
+    - perl-version-6:0.99.17-413.module_2073+eebc5b71.noarch
+    - perl-version-6:0.99.24-1.module_2073+eebc5b71.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: perl-bootstrap
+  stream: 5.24
+  version: 20180417065503
+  context: 6c81f848
+  arch: x86_64
+  summary: Perl bootstrap module for bootrapping Perl module
+  description: >
+    This is the Perl interpreter and a set of modules written in Perl language intended
+    for bootstrapping the perl module. This module disables some optional tests to
+    limit amount of components. This module is not intended for public use. It's an
+    intermediate step for building perl module.
+  license:
+    module:
+    - MIT
+    content:
+    - (Copyright only) and (Artistic or GPL+)
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic)
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic) and BSD and Public Domain and UCD
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic) and MIT
+    - (GPL+ or Artistic) and Artistic 2.0
+    - (GPL+ or Artistic) and Artistic 2.0 and UCD
+    - (GPL+ or Artistic) and BSD
+    - (GPL+ or Artistic) and CC0 and Public Domain
+    - (GPL+ or Artistic) and HSLR and MIT and UCD
+    - (GPL+ or Artistic) and MIT
+    - (GPL+ or Artistic) and Public Domain
+    - (GPL+ or Artistic) and UCD
+    - (GPL+ or Artistic) and Unicode
+    - (GPL+ or Artistic) and zlib
+    - (LGPLv2 or Artistic 2.0) and (GPL+ or Artistic)
+    - ASL 2.0
+    - Artistic 2.0
+    - BSD
+    - BSD and MIT
+    - GPL+
+    - GPL+ or Artistic
+    - GPLv2+ or Artistic
+    - GPLv2+ or Artistic 2.0
+    - GPLv3+
+    - LGPLv2+
+    - MIT
+    - TTWL
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/perl-bootstrap.git?#47f4825a1d5e2a8fd7b76583744ea8f2202c850c
+      commit: 47f4825a1d5e2a8fd7b76583744ea8f2202c850c
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        perl-Devel-Symdump:
+          ref: 8c2d0279e473e311cfcf0521091d3f93c221937a
+        perl-Test-Pod:
+          ref: 576a8c16670036dc9212fd54eabd0ef7d9d164c1
+        perl-File-Which:
+          ref: 1a2ca4a9b713f31c6f99f6dec3dafdd0a457a44f
+        perl-Perl-Version:
+          ref: 3efa7273f190e94ee96af9bbad3c137dc3b787c3
+        perl-Digest-MD5:
+          ref: 884cdd515f0250589dd4cde8c32a9d77fc55871e
+        perl-Test-Portability-Files:
+          ref: cdddd635bbdd7685819558be423e4456b66a090d
+        perl-Pod-Escapes:
+          ref: 1ab928503d1824c54a6a32e6b5d527b389f34d05
+        perl-Text-ParseWords:
+          ref: 1c120cf2934e246a59a5f37284ac8111c52fa806
+        perl-podlators:
+          ref: 380d587d637c4b5fe4c1b961aa16cb698ed2a07b
+        perl-Pod-Eventual:
+          ref: 4c8406d6788f6552c47df76ae69601a9de6486ff
+        perl-IPC-Cmd:
+          ref: fc6bc3efe40775d3e63d811a65ed0cab6aa138e1
+        perl-Test-Output:
+          ref: 8b0264e6c842946fe77b7c461275961680e62368
+        perl-SUPER:
+          ref: 5e0a1ed539e5948eeea71c3ad3d8ce124b4d63c2
+        perl-Time-Local:
+          ref: e74a3e804e77a0d704eebdede825b6d0d6cc617b
+        perl-IPC-SysV:
+          ref: 6102b15b4a3e30698673109ddda94a2325123e38
+        perl-Package-Generator:
+          ref: f78e39fa9dc3fd1474475eabcb9378375142dd70
+        perl-MRO-Compat:
+          ref: 13cfd3efff5d02609bf8fe0c36a9e7a9a37ca8b8
+        perl-IO-HTML:
+          ref: 69a460858b8c1f47bb6320faa6f310dab6808184
+        perl-Compress-Raw-Bzip2:
+          ref: b989d850d818cbaeba0c47b0d975e1afd6b34bb8
+        perl-Devel-Leak:
+          ref: aac20d847c0b0c781e9c6d49a4458526b9f9aa8b
+        perl-IO-String:
+          ref: e441228a5c401a96fdfa989706c0b4da67902cfc
+        perl:
+          ref: 9acafa0017b87ed96f8857fd7099787f0d24ff56
+        perl-File-Slurp-Tiny:
+          ref: 1f6426ab2ee83674668788199ec0a1ba676c1ec3
+        perl-Params-Util:
+          ref: 4bfebd9e4cb2fe6a52e2ae69d5e5e74b36296f9f
+        perl-File-Path:
+          ref: 5848e296d61a3de73f17016f7f37a6395ae0f402
+        perl-Sub-Uplevel:
+          ref: 7a179457e0f3068e923a4fe3db2dd74a68b72925
+        perl-Module-Load:
+          ref: 3f98c8f286677f7b700f661545154e781798ef0c
+        perl-CPAN-Meta-Requirements:
+          ref: f693254160585068bd1db62ffa980963a2ef7011
+        perl-Test-CPAN-Meta:
+          ref: 9aac31d337c0526dedcd5b36ba4d97e71a04cf8c
+        perl-IO-Socket-IP:
+          ref: 4e56568b5d09ad4aefccb354183614ae5b3f6235
+        perl-Test-Harness:
+          ref: 2ddba30c66331628ef273a6df6b67e2b05d76022
+        perl-parent:
+          ref: f50da57010454e2279d899a57fdbc65a48edc74c
+        perl-ExtUtils-CBuilder:
+          ref: 521e6f6f83dc9a5afbb517d85e637bfa69f59701
+        perl-perlfaq:
+          ref: 63e299c953b8f4b558fe904fc7d31763f79760f1
+        perl-Sub-Install:
+          ref: 799f7222e97cc90f9abb7e1f02a5847d71a83cb0
+        perl-IPC-System-Simple:
+          ref: c6c28f1091285aa29100a31c705bcf916a13452b
+        perl-Socket:
+          ref: 14bd5dedb6ff8da7d7b0f5945aa61ffa620777d1
+        perl-Perl-OSType:
+          ref: c2efc33ea89adb7c2da626cc3d436bbc69203e2b
+        perl-ExtUtils-ParseXS:
+          ref: 9398847c09b96f2765b1a03b4b84188e28711273
+        perl-Test-Deep:
+          ref: efc3846cd014e4c4adb0637da854b2413112cc9e
+        perl-IPC-Run:
+          ref: d123ca7ec60ceb684a6acf68ea4a492562bb2937
+        perl-Import-Into:
+          ref: 4964255b1b7b5d0b7c61f0f56db81963ce4b559e
+        perl-ExtUtils-Install:
+          ref: 507084f8349f691d4688fe9a49e92be1711874e4
+        perl-BSD-Resource:
+          ref: b0968a4d109d201a1318c0012f4e8f858d2f78d2
+        perl-autodie:
+          ref: 40735fb3b9a6b96b40934e72672bb1a04eb0999a
+        perl-Locale-Maketext:
+          ref: 57b31cf2d161ce97448d225af3f86c210d78ad6a
+        perl-Module-Runtime:
+          ref: b61338418e9c84469b3d76a17b70f38497d30dd7
+        perl-Data-OptList:
+          ref: 9512df0280d65abfaa04d6437367705c3b19b54f
+        perl-LWP-MediaTypes:
+          ref: 31f031d664748d5049327f8928d998ba1003d606
+        perl-CPAN-Meta-YAML:
+          ref: 3609aa7e2ae8ca137d9ff46de25d4b869fdb8c2b
+        perl-Math-BigInt-FastCalc:
+          ref: 785456ac9585a8b4f7628d3bd2a0dacd5b592d09
+        perl-File-Temp:
+          ref: de8e0c3e7e630e6861a0c0979c5ab60227f7de8e
+        perl-JSON-PP:
+          ref: 1e3fe253e7edbdc506418a38d666ed19db8ce136
+        perl-Test-Simple:
+          ref: e64b2e39f56e17d7b9046881d589c778aaf4ce8b
+        perl-File-Find-Object:
+          ref: 352249b989b0d30b7872918228edcb76cdc7836e
+        perl-Capture-Tiny:
+          ref: b62d26b13aced270b75df6b6fe3a2cc10f8e8987
+        perl-HTTP-Message:
+          ref: 3fb93e190e2804faea83abcb45214b00fd090bc5
+        perl-Pod-Coverage-TrustPod:
+          ref: f784cfffe48f00c3d1a8317581a940d2ae6268c1
+        perl-Module-Build:
+          ref: 2c9e4f8f3788caeaa4707f7b562f1ad39a416680
+        perl-inc-latest:
+          ref: 0a60ae8876d88d2eaac83b84d6d2fff8ced1b9a1
+        perl-Module-Load-Conditional:
+          ref: bb49232617058d8af4f199db9972f04cd3eefe0d
+        perl-Filter:
+          ref: 998996cc8b57f55172167da01155d3a7b59c1e99
+        perl-Pod-Checker:
+          ref: 6c8f684a9863678be5724c2e565ba1aa62761151
+        perl-Sort-Versions:
+          ref: c4677aff1f40cf996fb73d0d1312c2583434fa6b
+        perl-Thread-Queue:
+          ref: e0fff689fc097ecf54bac2f09e5e7bd3c4d00ef6
+        perl-IO-Compress:
+          ref: 1e67f30fcc790e2d133ecd756e1b68dc1e423999
+        perl-Math-BigInt:
+          ref: 82d8ddba8d0d808a04d9d4cb579df53f65112027
+        perl-File-Find-Rule:
+          ref: d948339f4b97b6ce271c9c288b144cf967411043
+        perl-Text-Template:
+          ref: 9309a484a2e8e309272c8916cf63a12e385eaaef
+        perl-Test-Exception:
+          ref: b78e90750d6fb261ce29ad3a347b1e394c612331
+        perl-Unicode-Normalize:
+          ref: 6875f415710668a788423fdd80ae712e0c3d3ab2
+        perl-HTML-Tagset:
+          ref: b4bb7fb9dd897fed415210afbaa904bfb7fd4e45
+        perl-URI:
+          ref: 28d53fda027d3a984ffa201d4494389c6b7796b0
+        perl-GSSAPI:
+          ref: 248a8c09ceed073a724a44e11d65fc15fc792201
+        perl-TermReadKey:
+          ref: 012af49cc9a63d1d481cb616a21b0f3545aefe23
+        perl-Text-Glob:
+          ref: 346be0660f0fc621a960467b5fa1ee656b9cd87f
+        perl-Pod-Simple:
+          ref: a0eec0341f8cc19d74f6f21f9bf38781446a0ad1
+        perl-Algorithm-Diff:
+          ref: f4b6c06396d4768c691a23b3b967fe6fac1e46ee
+        perl-Class-XSAccessor:
+          ref: c9edaedd473078571b2fd3de7743c69f0cc67f1a
+        perl-Digest:
+          ref: 6867766aaf85865d33675be774af4751b8ae9549
+        perl-Test-FailWarnings:
+          ref: 6d8ce49b232ead21cf55098590e10eb897d24426
+        perl-Tie-IxHash:
+          ref: 8e7169c7705dddb6290c1d8c116c5ca4eb1de7a4
+        perl-ExtUtils-MakeMaker:
+          ref: 5d9438be138d0919320b5a6e2324df05fe123d6a
+        perl-Devel-StackTrace:
+          ref: 64a31414eda5c263e7bea908641ad4e44c46de31
+        perl-Compress-Raw-Zlib:
+          ref: ed5582bb24c481aaa0de7a33ecbf85989e0ddd8c
+        perl-Test-Version:
+          ref: f5adf2bc958c6bb1c847fd9e355df70285cf38fb
+        perl-ExtUtils-Manifest:
+          ref: 2fd5140cb9441b0445de12b720c5459ed38e95b7
+        perl-Pod-Parser:
+          ref: efe0977afc65bae502a4ee5bc47430b4e2b6702f
+        perl-Exporter:
+          ref: 14c101bc77bc5119c4f75065d6f4b6edea4b502a
+        perl-MIME-Base64:
+          ref: da62d3707ea9781efc91ba48d47ce49b2297a364
+        perl-version:
+          ref: 098155010f833f432a85cb97754e1080750ec873
+        perl-experimental:
+          ref: cad2845a55a98ca9565be2707c3ff48e984fd1da
+        perl-Text-Levenshtein-Damerau-XS:
+          ref: 920027ab00d12e5a2e6b12e2e8d7f0b23fd6f1c1
+        perl-CPAN:
+          ref: 4159d449e5a66ddef70d1fe7f1d37279d4d99bc5
+        perl-Text-Balanced:
+          ref: c6648ff72f7b1798642f719036a677102c7ee125
+        perl-PathTools:
+          ref: e643e0b6864983a2606f5bcf3ae9a34caeda4059
+        perl-Compress-Bzip2:
+          ref: 1ac091378670bfc36b3e866924ddc076cd800cf2
+        perl-Number-Compare:
+          ref: a3e2f8c0ea3542cde8009225501e8c09cad2582d
+        perl-Authen-SASL:
+          ref: a21e64f1a36fd53125e5a79287c34b2f16fc9782
+        perl-JSON:
+          ref: 7e6037e3c89511b23511c4292ce1129ef43dd09c
+        perl-Fedora-VSP:
+          ref: 63312d7720e816853bd595cbcdc9d9e3cce0880b
+        perl-Test-NoWarnings:
+          ref: ff0744a0c58a759894a7296f4f47aec3522105a5
+        perl-Locale-Codes:
+          ref: bd6e31d21f18e85ffe4411b0ce7238d6a974063a
+        perl-Digest-HMAC:
+          ref: 74df7c0a82a218beba053d129a0d29fa74316724
+        perl-Module-CoreList:
+          ref: 6b31db0c22a4824a2ae7c40114a8af17bcfd125b
+        perl-Scalar-List-Utils:
+          ref: 7eb2ea6397b7fbeeaeacbb176bbbc453723ded1a
+        perl-Digest-SHA:
+          ref: 2b4a62eaf739a7d2ce6649f3a326dbd562ed8b74
+        perl-CPAN-Meta-Check:
+          ref: 4c4b5bd0d549adebf27a79f755db22dadb324d70
+        perl-Expect:
+          ref: 9b537a758488cd3f11288f65eb76384f562bed93
+        perl-TimeDate:
+          ref: f375f3f228c209a12ac22d1055ddeba07e01134b
+        perl-Pod-Coverage:
+          ref: ec582e4dc33ea441ec00496a2123333052834e59
+        perl-generators:
+          ref: 87c9a690dd58beeaa573074d26fccccb089ab31b
+        perl-Pod-Perldoc:
+          ref: 842e567a333ccfd2b15be93f230d29414be0f581
+        perl-Sub-Exporter:
+          ref: 92259c19826f0aed436f04d886cf4e1f208ff103
+        perl-Time-HiRes:
+          ref: 17004a2568fc6de651cee58816cec8640a825d4c
+        perl-HTTP-Tiny:
+          ref: d396ccfe1aadc5746420b06e268e04316eb62c44
+        perl-Test-Taint:
+          ref: c72c54ac4c5cde555381dd2b4037d0a34af36af4
+        perl-Text-Tabs+Wrap:
+          ref: 90b3a77c499b10b5d34569f8b1b26327495049ea
+        perl-B-Debug:
+          ref: ec558193299b89d6babcf009bdcc18dc7fc48a4e
+        perl-File-HomeDir:
+          ref: 2982c5d9f538d8c640c3ca8fee7566d68e5ea68e
+        perl-threads:
+          ref: f0b3ca4a1602b11c483d97aea130e2dea8b8f96f
+        perl-accessors:
+          ref: 0e851a02363f4433b6fa5822553ba810f2127711
+        perl-Unicode-Collate:
+          ref: c6bc5268528635406bf3237258e7c2969a2bdfc6
+        perl-YAML-Syck:
+          ref: 5454878158f3a1eca83b59ebbff5f21b1284a3af
+        perl-Encode-Locale:
+          ref: b0a26b89329c19ad11b5bb5a3292b960f74563e0
+        perl-Try-Tiny:
+          ref: e6ae51897ab12408471d9a6285d2cb6a472aff65
+        perl-Text-Diff:
+          ref: 2ee347e962b8a0e83eeecf3324062308cc1d1a2c
+        perl-threads-shared:
+          ref: cd6fd55c5d0ce4aaf7394f4ee865d68c61e91cd1
+        perl-Math-BigRat:
+          ref: 72d54e7b07b44e1b126a961e8ac44b346d9ee7de
+        perl-HTML-Parser:
+          ref: 91f7240000e51a6838eb39a25a63bd329cc4ed9d
+        perl-Storable:
+          ref: d76f7a7ba835789a1ca93e3c0db2fc17a9f11907
+        perl-Getopt-Long:
+          ref: a7414b0c7a488b9af202fff1eb6a2fb2a3ca6327
+        perl-Digest-SHA1:
+          ref: ac79089f89be4e77521118399bf9f27ea9acebf0
+        perl-bignum:
+          ref: 74c0852bf10b97499c694d3d32f5e66a7a7d7cf3
+        perl-Net-SSLeay:
+          ref: 62017fc4159c66debfa779e71c05bd206a411650
+        perl-Term-ANSIColor:
+          ref: 3a74f9162f818ffaa4069d74c931caef0560514b
+        perl-IO-Tty:
+          ref: 5d0e7d74fd5f707edf41bb8d9dcbf4e40d8227d9
+        perl-Net-IDN-Encode:
+          ref: 460f7f72751e3c81d09d566073944962ab4d6411
+        perl-Carp:
+          ref: 84fbaf6f236f9a082ae6960bbbd160f6e75894c5
+        perl-libnet:
+          ref: e6cc3a47e0776ada93c3801f06af81fb7b642d38
+        perl-Test-Pod-Coverage:
+          ref: 010a282957d054909aeda5efa3a699fd3c7992f7
+        perl-local-lib:
+          ref: 96f72250500b509a87fe9263b81f888812ba08cf
+        perl-Test-TrailingSpace:
+          ref: d6e33a6af0540130b87353ba17160e222252cb89
+        perl-Params-Check:
+          ref: cf2ab4714451509691e4c06f968b0cc71891a8b8
+        perl-File-Find-Rule-Perl:
+          ref: d9c5ed29fbca16a094c2e8c13f9a7d316b0309f4
+        perl-Mixin-Linewise:
+          ref: 00c2d1043dcd5241042440ab1db81dc4442b0717
+        perl-Pod-Usage:
+          ref: 9d38a4ee92dafbfdd5e8adf44810304de6bbc9e0
+        perl-Data-Dumper:
+          ref: c8ea0bbaafa024bc09c7f29342f584885571eb07
+        perl-Data-Section:
+          ref: 6ed48ef1733de62cd245237e25d93ea9a827d5e6
+        perl-Socket6:
+          ref: 81332b86b363354a64ae9a952464963b2364e1a4
+        perl-File-Fetch:
+          ref: b4bf1bd8af7755b16b40a3dd67cb743bef9b1652
+        perl-HTTP-Date:
+          ref: 10316c369112a515f0e98539bfbef604709aad25
+        perl-Software-License:
+          ref: da9a11a3ad14d5a4cbfe9b52d108b672a6939d69
+        perl-IO-Socket-SSL:
+          ref: 0127aa728ad530065708aee31fa1bb31309c574a
+        perl-Env:
+          ref: 58ac31466f9c9824d25b13ad559622dcdd65e20a
+        perl-Config-Perl-V:
+          ref: 5a2c9f1ea41e4f07e76062c9598619fed2b4dcb6
+        perl-IO-Socket-INET6:
+          ref: a94e5c6c12df30734570d0b2587ae0b19f1e6e6a
+        perl-Archive-Tar:
+          ref: 2bd7368d3debb90e1d87c3d44db91412fd39873c
+        perl-Test-Warn:
+          ref: 55255a6e3e3379784b9d3dc982d3ffbcefca0912
+        perl-Devel-Size:
+          ref: 982a54ab4a98fba5339f850fa9cc30af93703d2f
+        perl-Test-MockModule:
+          ref: 89e06b4276d3db97152535beb7b18245643d78de
+        perl-Term-Cap:
+          ref: 28e345f7f785aa5b60572bfa5ba2627ef8dd3033
+        perl-Sys-Syslog:
+          ref: 008e476eb1f3e015ad34f302a4cad874e4aad33a
+        perl-Devel-PPPort:
+          ref: bd144f784620e5cb43ef9aea61c11d1bb7fe0503
+        perl-CGI:
+          ref: 813b1d1505d678db76a08eade6cde0592ab01c76
+        perl-CPAN-Meta:
+          ref: 68ca8b0eed6d50eaef11c381b6d8e4754f6c2a7d
+        perl-File-Find-Object-Rule:
+          ref: da140b5d0f2f2555c56b2c0d98520b57b263b5fe
+        perl-Archive-Zip:
+          ref: 948b8e44e8dc5def0baa82a96c46da5bff385086
+        perl-DB_File:
+          ref: d9d4b751bd8ea51672630f3beb1ecaf899de40ad
+        perl-PerlIO-utf8_strict:
+          ref: 58caa0d757a324f86b5c9d6a8e27abb230ffc5e7
+        perl-YAML:
+          ref: 5b3a5ddc9c27dae306b39436c62ba1343a745b5d
+        perl-Sub-Identify:
+          ref: ab54ce7ae8646b1faf1ce345b82a042c21272ff6
+        perl-Filter-Simple:
+          ref: ca5e4217e059a7371a125419071852760d031dba
+        perl-Module-Metadata:
+          ref: f583f7db4daab0a72bae86e49b549c15f5e2c905
+        perl-Net-LibIDN:
+          ref: b4176cefa2675271f48e4c28314baa018abdf887
+        perl-PerlIO-via-QuotedPrint:
+          ref: 31eb1e0e1c723aaf09d6846b9016e4db94428700
+        perl-constant:
+          ref: f005b65dee6a48411e2dfeb5e057dfb8a3818135
+        perl-Encode:
+          ref: 346cfe7ccbce4c3cc2a4739b628d8d0b7e1a4779
+    mbs_options:
+      blocked_packages:
+      - perl
+      - perl-accessors
+      - perl-Algorithm-Diff
+      - perl-Archive-Tar
+      - perl-Archive-Zip
+      - perl-Authen-SASL
+      - perl-autodie
+      - perl-B-Debug
+      - perl-bignum
+      - perl-BSD-Resource
+      - perl-Capture-Tiny
+      - perl-Carp
+      - perl-CGI
+      - perl-Class-XSAccessor
+      - perl-Compress-Bzip2
+      - perl-Compress-Raw-Bzip2
+      - perl-Compress-Raw-Zlib
+      - perl-Config-Perl-V
+      - perl-constant
+      - perl-CPAN
+      - perl-CPAN-Meta
+      - perl-CPAN-Meta-Check
+      - perl-CPAN-Meta-Requirements
+      - perl-CPAN-Meta-YAML
+      - perl-Data-Dumper
+      - perl-Data-OptList
+      - perl-Data-Section
+      - perl-DB_File
+      - perl-Devel-Leak
+      - perl-Devel-PPPort
+      - perl-Devel-Size
+      - perl-Devel-StackTrace
+      - perl-Devel-Symdump
+      - perl-Digest
+      - perl-Digest-HMAC
+      - perl-Digest-MD5
+      - perl-Digest-SHA
+      - perl-Digest-SHA1
+      - perl-Encode
+      - perl-Encode-Locale
+      - perl-Env
+      - perl-Expect
+      - perl-experimental
+      - perl-Exporter
+      - perl-ExtUtils-CBuilder
+      - perl-ExtUtils-Install
+      - perl-ExtUtils-MakeMaker
+      - perl-ExtUtils-Manifest
+      - perl-ExtUtils-ParseXS
+      - perl-Fedora-VSP
+      - perl-File-Fetch
+      - perl-File-Find-Object
+      - perl-File-Find-Object-Rule
+      - perl-File-Find-Rule
+      - perl-File-Find-Rule-Perl
+      - perl-File-HomeDir
+      - perl-File-Path
+      - perl-File-Slurp-Tiny
+      - perl-File-Temp
+      - perl-File-Which
+      - perl-Filter
+      - perl-Filter-Simple
+      - perl-generators
+      - perl-Getopt-Long
+      - perl-GSSAPI
+      - perl-HTML-Parser
+      - perl-HTML-Tagset
+      - perl-HTTP-Date
+      - perl-HTTP-Message
+      - perl-HTTP-Tiny
+      - perl-Import-Into
+      - perl-inc-latest
+      - perl-IO-Compress
+      - perl-IO-HTML
+      - perl-IO-Socket-INET6
+      - perl-IO-Socket-IP
+      - perl-IO-Socket-SSL
+      - perl-IO-String
+      - perl-IO-Tty
+      - perl-IPC-Cmd
+      - perl-IPC-Run
+      - perl-IPC-System-Simple
+      - perl-IPC-SysV
+      - perl-JSON
+      - perl-JSON-PP
+      - perl-libnet
+      - perl-local-lib
+      - perl-Locale-Codes
+      - perl-Locale-Maketext
+      - perl-LWP-MediaTypes
+      - perl-Math-BigInt
+      - perl-Math-BigInt-FastCalc
+      - perl-Math-BigRat
+      - perl-MIME-Base64
+      - perl-Mixin-Linewise
+      - perl-Module-Build
+      - perl-Module-CoreList
+      - perl-Module-Load
+      - perl-Module-Load-Conditional
+      - perl-Module-Metadata
+      - perl-Module-Runtime
+      - perl-MRO-Compat
+      - perl-Net-IDN-Encode
+      - perl-Net-LibIDN
+      - perl-Net-SSLeay
+      - perl-Number-Compare
+      - perl-Package-Generator
+      - perl-Params-Check
+      - perl-Params-Util
+      - perl-parent
+      - perl-PathTools
+      - perl-Perl-OSType
+      - perl-Perl-Version
+      - perl-perlfaq
+      - perl-PerlIO-utf8_strict
+      - perl-PerlIO-via-QuotedPrint
+      - perl-Pod-Checker
+      - perl-Pod-Coverage
+      - perl-Pod-Coverage-TrustPod
+      - perl-Pod-Escapes
+      - perl-Pod-Eventual
+      - perl-Pod-Parser
+      - perl-Pod-Perldoc
+      - perl-Pod-Simple
+      - perl-Pod-Usage
+      - perl-podlators
+      - perl-Scalar-List-Utils
+      - perl-Socket
+      - perl-Socket6
+      - perl-Software-License
+      - perl-Sort-Versions
+      - perl-Storable
+      - perl-Sub-Exporter
+      - perl-Sub-Identify
+      - perl-Sub-Install
+      - perl-Sub-Uplevel
+      - perl-SUPER
+      - perl-Sys-Syslog
+      - perl-Term-ANSIColor
+      - perl-Term-Cap
+      - perl-TermReadKey
+      - perl-Test-CPAN-Meta
+      - perl-Test-Deep
+      - perl-Test-Exception
+      - perl-Test-FailWarnings
+      - perl-Test-Harness
+      - perl-Test-MockModule
+      - perl-Test-NoWarnings
+      - perl-Test-Output
+      - perl-Test-Pod
+      - perl-Test-Pod-Coverage
+      - perl-Test-Portability-Files
+      - perl-Test-Simple
+      - perl-Test-Taint
+      - perl-Test-TrailingSpace
+      - perl-Test-Version
+      - perl-Test-Warn
+      - perl-Text-Balanced
+      - perl-Text-Diff
+      - perl-Text-Glob
+      - perl-Text-Levenshtein-Damerau-XS
+      - perl-Text-ParseWords
+      - perl-Text-Tabs+Wrap
+      - perl-Text-Template
+      - perl-Thread-Queue
+      - perl-threads
+      - perl-threads-shared
+      - perl-Tie-IxHash
+      - perl-Time-HiRes
+      - perl-Time-Local
+      - perl-TimeDate
+      - perl-Try-Tiny
+      - perl-Unicode-Collate
+      - perl-Unicode-Normalize
+      - perl-URI
+      - perl-version
+      - perl-YAML
+      - perl-YAML-Syck
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://fedoraproject.org/wiki/Modularity
+    documentation: https://fedoraproject.org/wiki/Fedora_Packaging_Guidelines_for_Modules
+  buildopts:
+    rpms:
+      macros: |
+        %perl_bootstrap 1
+        %_with_perl_enables_groff 1
+        %_without_perl_enables_syslog_test 1
+        %_with_perl_enables_systemtap 1
+        %_without_perl_enables_tcsh 1
+        %_without_perl_Compress_Bzip2_enables_optional_test 1
+        %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+        %_without_perl_IPC_System_Simple_enables_optional_test 1
+        %_without_perl_LWP_MediaTypes_enables_mailcap 1
+        %_without_perl_Module_Build_enables_optional_test 1
+        %_without_perl_Perl_OSType_enables_optional_test 1
+        %_without_perl_Pod_Perldoc_enables_tk_test 1
+        %_without_perl_Software_License_enables_optional_test 1
+        %_without_perl_Sys_Syslog_enables_optional_test 1
+        %_without_perl_Test_Harness_enables_optional_test 1
+        %_without_perl_URI_enables_Business_ISBN 1
+  components:
+    rpms:
+      perl:
+        rationale: The Perl interpreter.
+        repository: git://pkgs.fedoraproject.org/rpms/perl
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl
+        ref: f26
+        buildorder: 1
+      perl-Algorithm-Diff:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Algorithm-Diff
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Algorithm-Diff
+        ref: f26
+        buildorder: 4
+      perl-Archive-Tar:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Archive-Tar
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Archive-Tar
+        ref: f26
+        buildorder: 4
+      perl-Archive-Zip:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Archive-Zip
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Archive-Zip
+        ref: f26
+        buildorder: 8
+      perl-Authen-SASL:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Authen-SASL
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Authen-SASL
+        ref: f26
+        buildorder: 6
+      perl-B-Debug:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-B-Debug
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-B-Debug
+        ref: f26
+        buildorder: 4
+      perl-BSD-Resource:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-BSD-Resource
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-BSD-Resource
+        ref: f26
+        buildorder: 7
+      perl-CGI:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CGI
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CGI
+        ref: f26
+        buildorder: 6
+      perl-CPAN:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN
+        ref: f26
+        buildorder: 6
+      perl-CPAN-Meta:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta
+        ref: f26
+        buildorder: 4
+      perl-CPAN-Meta-Check:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-Check
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-Check
+        ref: f26
+        buildorder: 10
+      perl-CPAN-Meta-Requirements:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-Requirements
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-Requirements
+        ref: f26
+        buildorder: 4
+      perl-CPAN-Meta-YAML:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-YAML
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-YAML
+        ref: f26
+        buildorder: 4
+      perl-Capture-Tiny:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Capture-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Capture-Tiny
+        ref: f26
+        buildorder: 4
+      perl-Carp:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Carp
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Carp
+        ref: f26
+        buildorder: 4
+      perl-Class-XSAccessor:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Class-XSAccessor
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Class-XSAccessor
+        ref: f26
+        buildorder: 4
+      perl-Compress-Bzip2:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Bzip2
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Bzip2
+        ref: f26
+        buildorder: 4
+      perl-Compress-Raw-Bzip2:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Raw-Bzip2
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Raw-Bzip2
+        ref: f26
+        buildorder: 4
+      perl-Compress-Raw-Zlib:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Raw-Zlib
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Raw-Zlib
+        ref: f26
+        buildorder: 4
+      perl-Config-Perl-V:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Config-Perl-V
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Config-Perl-V
+        ref: f26
+        buildorder: 6
+      perl-DB_File:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-DB_File
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-DB_File
+        ref: f26
+        buildorder: 4
+      perl-Data-Dumper:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-Dumper
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-Dumper
+        ref: f26
+        buildorder: 4
+      perl-Data-OptList:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-OptList
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-OptList
+        ref: f26
+        buildorder: 5
+      perl-Data-Section:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-Section
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-Section
+        ref: f26
+        buildorder: 7
+      perl-Devel-Leak:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-Leak
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-Leak
+        ref: f26
+        buildorder: 4
+      perl-Devel-PPPort:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-PPPort
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-PPPort
+        ref: f26
+        buildorder: 4
+      perl-Devel-Size:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-Size
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-Size
+        ref: f26
+        buildorder: 7
+      perl-Devel-StackTrace:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-StackTrace
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-StackTrace
+        ref: f26
+        buildorder: 4
+      perl-Devel-Symdump:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-Symdump
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-Symdump
+        ref: f26
+        buildorder: 4
+      perl-Digest:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest
+        ref: f26
+        buildorder: 4
+      perl-Digest-HMAC:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-HMAC
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-HMAC
+        ref: f26
+        buildorder: 5
+      perl-Digest-MD5:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-MD5
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-MD5
+        ref: f26
+        buildorder: 4
+      perl-Digest-SHA:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-SHA
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-SHA
+        ref: f26
+        buildorder: 4
+      perl-Digest-SHA1:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-SHA1
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-SHA1
+        ref: f26
+        buildorder: 4
+      perl-Encode:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Encode
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Encode
+        ref: f26
+        buildorder: 4
+      perl-Encode-Locale:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Encode-Locale
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Encode-Locale
+        ref: f26
+        buildorder: 4
+      perl-Env:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Env
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Env
+        ref: f26
+        buildorder: 4
+      perl-Expect:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Expect
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Expect
+        ref: f26
+        buildorder: 5
+      perl-Exporter:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Exporter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Exporter
+        ref: f26
+        buildorder: 4
+      perl-ExtUtils-CBuilder:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-CBuilder
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-CBuilder
+        ref: f26
+        buildorder: 4
+      perl-ExtUtils-Install:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-Install
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-Install
+        ref: f26
+        buildorder: 4
+      perl-ExtUtils-MakeMaker:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-MakeMaker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-MakeMaker
+        ref: f26
+        buildorder: 4
+      perl-ExtUtils-Manifest:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-Manifest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-Manifest
+        ref: f26
+        buildorder: 4
+      perl-ExtUtils-ParseXS:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-ParseXS
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-ParseXS
+        ref: f26
+        buildorder: 4
+      perl-Fedora-VSP:
+        rationale: RPM dependency generator.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Fedora-VSP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Fedora-VSP
+        ref: f26
+        buildorder: 2
+      perl-File-Fetch:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Fetch
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Fetch
+        ref: f26
+        buildorder: 5
+      perl-File-Find-Object:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Find-Object
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Find-Object
+        ref: f26
+        buildorder: 5
+      perl-File-Find-Object-Rule:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Find-Object-Rule
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Find-Object-Rule
+        ref: f26
+        buildorder: 6
+      perl-File-Find-Rule:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Find-Rule
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Find-Rule
+        ref: f26
+        buildorder: 5
+      perl-File-Find-Rule-Perl:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Find-Rule-Perl
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Find-Rule-Perl
+        ref: f26
+        buildorder: 6
+      perl-File-HomeDir:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-HomeDir
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-HomeDir
+        ref: f26
+        buildorder: 5
+      perl-File-Path:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Path
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Path
+        ref: f26
+        buildorder: 4
+      perl-File-Slurp-Tiny:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Slurp-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Slurp-Tiny
+        ref: f26
+        buildorder: 4
+      perl-File-Temp:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Temp
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Temp
+        ref: f26
+        buildorder: 4
+      perl-File-Which:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Which
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Which
+        ref: f26
+        buildorder: 4
+      perl-Filter:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Filter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Filter
+        ref: f26
+        buildorder: 4
+      perl-Filter-Simple:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Filter-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Filter-Simple
+        ref: f26
+        buildorder: 4
+      perl-GSSAPI:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-GSSAPI
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-GSSAPI
+        ref: f26
+        buildorder: 4
+      perl-Getopt-Long:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Getopt-Long
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Getopt-Long
+        ref: f26
+        buildorder: 4
+      perl-HTML-Parser:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTML-Parser
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTML-Parser
+        ref: f26
+        buildorder: 5
+      perl-HTML-Tagset:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTML-Tagset
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTML-Tagset
+        ref: f26
+        buildorder: 4
+      perl-HTTP-Date:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTTP-Date
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTTP-Date
+        ref: f26
+        buildorder: 4
+      perl-HTTP-Message:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTTP-Message
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTTP-Message
+        ref: f26
+        buildorder: 5
+      perl-HTTP-Tiny:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTTP-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTTP-Tiny
+        ref: f26
+        buildorder: 4
+      perl-IO-Compress:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Compress
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Compress
+        ref: f26
+        buildorder: 5
+      perl-IO-HTML:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-HTML
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-HTML
+        ref: f26
+        buildorder: 4
+      perl-IO-Socket-INET6:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Socket-INET6
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Socket-INET6
+        ref: f26
+        buildorder: 8
+      perl-IO-Socket-IP:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Socket-IP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Socket-IP
+        ref: f26
+        buildorder: 4
+      perl-IO-Socket-SSL:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Socket-SSL
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Socket-SSL
+        ref: f26
+        buildorder: 9
+      perl-IO-String:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-String
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-String
+        ref: f26
+        buildorder: 4
+      perl-IO-Tty:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Tty
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Tty
+        ref: f26
+        buildorder: 4
+      perl-IPC-Cmd:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-Cmd
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-Cmd
+        ref: f26
+        buildorder: 6
+      perl-IPC-Run:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-Run
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-Run
+        ref: f26
+        buildorder: 5
+      perl-IPC-SysV:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-SysV
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-SysV
+        ref: f26
+        buildorder: 4
+      perl-IPC-System-Simple:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-System-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-System-Simple
+        ref: f26
+        buildorder: 4
+      perl-Import-Into:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Import-Into
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Import-Into
+        ref: f26
+        buildorder: 8
+      perl-JSON:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-JSON
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-JSON
+        ref: f26
+        buildorder: 7
+      perl-JSON-PP:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-JSON-PP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-JSON-PP
+        ref: f26
+        buildorder: 4
+      perl-LWP-MediaTypes:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-LWP-MediaTypes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-LWP-MediaTypes
+        ref: f26
+        buildorder: 4
+      perl-Locale-Codes:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Locale-Codes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Locale-Codes
+        ref: f26
+        buildorder: 4
+      perl-Locale-Maketext:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Locale-Maketext
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Locale-Maketext
+        ref: f26
+        buildorder: 4
+      perl-MIME-Base64:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-MIME-Base64
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-MIME-Base64
+        ref: f26
+        buildorder: 4
+      perl-MRO-Compat:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-MRO-Compat
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-MRO-Compat
+        ref: f26
+        buildorder: 4
+      perl-Math-BigInt:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigInt
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigInt
+        ref: f26
+        buildorder: 4
+      perl-Math-BigInt-FastCalc:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigInt-FastCalc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigInt-FastCalc
+        ref: f26
+        buildorder: 5
+      perl-Math-BigRat:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigRat
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigRat
+        ref: f26
+        buildorder: 5
+      perl-Mixin-Linewise:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Mixin-Linewise
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Mixin-Linewise
+        ref: f26
+        buildorder: 7
+      perl-Module-Build:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Build
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Build
+        ref: f26
+        buildorder: 5
+      perl-Module-CoreList:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-CoreList
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-CoreList
+        ref: f26
+        buildorder: 4
+      perl-Module-Load:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Load
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Load
+        ref: f26
+        buildorder: 4
+      perl-Module-Load-Conditional:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Load-Conditional
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Load-Conditional
+        ref: f26
+        buildorder: 4
+      perl-Module-Metadata:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Metadata
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Metadata
+        ref: f26
+        buildorder: 4
+      perl-Module-Runtime:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Runtime
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Runtime
+        ref: f26
+        buildorder: 7
+      perl-Net-IDN-Encode:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Net-IDN-Encode
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Net-IDN-Encode
+        ref: f26
+        buildorder: 7
+      perl-Net-LibIDN:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Net-LibIDN
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Net-LibIDN
+        ref: f26
+        buildorder: 4
+      perl-Net-SSLeay:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Net-SSLeay
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Net-SSLeay
+        ref: f26
+        buildorder: 6
+      perl-Number-Compare:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Number-Compare
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Number-Compare
+        ref: f26
+        buildorder: 4
+      perl-Package-Generator:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Package-Generator
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Package-Generator
+        ref: f26
+        buildorder: 5
+      perl-Params-Check:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Params-Check
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Params-Check
+        ref: f26
+        buildorder: 4
+      perl-Params-Util:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Params-Util
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Params-Util
+        ref: f26
+        buildorder: 4
+      perl-PathTools:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PathTools
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PathTools
+        ref: f26
+        buildorder: 4
+      perl-Perl-OSType:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Perl-OSType
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Perl-OSType
+        ref: f26
+        buildorder: 4
+      perl-Perl-Version:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Perl-Version
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Perl-Version
+        ref: f26
+        buildorder: 7
+      perl-PerlIO-utf8_strict:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PerlIO-utf8_strict
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PerlIO-utf8_strict
+        ref: f26
+        buildorder: 6
+      perl-PerlIO-via-QuotedPrint:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PerlIO-via-QuotedPrint
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PerlIO-via-QuotedPrint
+        ref: f26
+        buildorder: 4
+      perl-Pod-Checker:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Checker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Checker
+        ref: f26
+        buildorder: 4
+      perl-Pod-Coverage:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Coverage
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Coverage
+        ref: f26
+        buildorder: 5
+      perl-Pod-Coverage-TrustPod:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Coverage-TrustPod
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Coverage-TrustPod
+        ref: f26
+        buildorder: 9
+      perl-Pod-Escapes:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Escapes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Escapes
+        ref: f26
+        buildorder: 4
+      perl-Pod-Eventual:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Eventual
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Eventual
+        ref: f26
+        buildorder: 8
+      perl-Pod-Parser:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Parser
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Parser
+        ref: f26
+        buildorder: 4
+      perl-Pod-Perldoc:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Perldoc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Perldoc
+        ref: f26
+        buildorder: 4
+      perl-Pod-Simple:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Simple
+        ref: f26
+        buildorder: 4
+      perl-Pod-Usage:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Usage
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Usage
+        ref: f26
+        buildorder: 4
+      perl-SUPER:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-SUPER
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-SUPER
+        ref: f26
+        buildorder: 6
+      perl-Scalar-List-Utils:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Scalar-List-Utils
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Scalar-List-Utils
+        ref: f26
+        buildorder: 4
+      perl-Socket:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Socket
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Socket
+        ref: f26
+        buildorder: 4
+      perl-Socket6:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Socket6
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Socket6
+        ref: f26
+        buildorder: 4
+      perl-Software-License:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Software-License
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Software-License
+        ref: f26
+        buildorder: 12
+      perl-Sort-Versions:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sort-Versions
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sort-Versions
+        ref: f26
+        buildorder: 4
+      perl-Storable:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Storable
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Storable
+        ref: f26
+        buildorder: 4
+      perl-Sub-Exporter:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Exporter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Exporter
+        ref: f26
+        buildorder: 6
+      perl-Sub-Identify:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Identify
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Identify
+        ref: f26
+        buildorder: 5
+      perl-Sub-Install:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Install
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Install
+        ref: f26
+        buildorder: 4
+      perl-Sub-Uplevel:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Uplevel
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Uplevel
+        ref: f26
+        buildorder: 4
+      perl-Sys-Syslog:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sys-Syslog
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sys-Syslog
+        ref: f26
+        buildorder: 4
+      perl-Term-ANSIColor:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Term-ANSIColor
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Term-ANSIColor
+        ref: f26
+        buildorder: 5
+      perl-Term-Cap:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Term-Cap
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Term-Cap
+        ref: f26
+        buildorder: 4
+      perl-TermReadKey:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-TermReadKey
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-TermReadKey
+        ref: f26
+        buildorder: 4
+      perl-Test-CPAN-Meta:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-CPAN-Meta
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-CPAN-Meta
+        ref: f26
+        buildorder: 7
+      perl-Test-Deep:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Deep
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Deep
+        ref: f26
+        buildorder: 4
+      perl-Test-Exception:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Exception
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Exception
+        ref: f26
+        buildorder: 5
+      perl-Test-FailWarnings:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-FailWarnings
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-FailWarnings
+        ref: f26
+        buildorder: 5
+      perl-Test-Harness:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Harness
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Harness
+        ref: f26
+        buildorder: 4
+      perl-Test-MockModule:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-MockModule
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-MockModule
+        ref: f26
+        buildorder: 7
+      perl-Test-NoWarnings:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-NoWarnings
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-NoWarnings
+        ref: f26
+        buildorder: 5
+      perl-Test-Output:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Output
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Output
+        ref: f26
+        buildorder: 7
+      perl-Test-Pod:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Pod
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Pod
+        ref: f26
+        buildorder: 4
+      perl-Test-Pod-Coverage:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Pod-Coverage
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Pod-Coverage
+        ref: f26
+        buildorder: 6
+      perl-Test-Portability-Files:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Portability-Files
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Portability-Files
+        ref: f26
+        buildorder: 4
+      perl-Test-Simple:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Simple
+        ref: f26
+        buildorder: 4
+      perl-Test-Taint:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Taint
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Taint
+        ref: f26
+        buildorder: 7
+      perl-Test-TrailingSpace:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-TrailingSpace
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-TrailingSpace
+        ref: f26
+        buildorder: 7
+      perl-Test-Version:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Version
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Version
+        ref: f26
+        buildorder: 7
+      perl-Test-Warn:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Warn
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Warn
+        ref: f26
+        buildorder: 5
+      perl-Text-Balanced:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Balanced
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Balanced
+        ref: f26
+        buildorder: 4
+      perl-Text-Diff:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Diff
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Diff
+        ref: f26
+        buildorder: 5
+      perl-Text-Glob:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Glob
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Glob
+        ref: f26
+        buildorder: 4
+      perl-Text-Levenshtein-Damerau-XS:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Levenshtein-Damerau-XS
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Levenshtein-Damerau-XS
+        ref: f26
+        buildorder: 4
+      perl-Text-ParseWords:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-ParseWords
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-ParseWords
+        ref: f26
+        buildorder: 4
+      perl-Text-Tabs+Wrap:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Tabs+Wrap
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Tabs+Wrap
+        ref: f26
+        buildorder: 4
+      perl-Text-Template:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Template
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Template
+        ref: f26
+        buildorder: 4
+      perl-Thread-Queue:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Thread-Queue
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Thread-Queue
+        ref: f26
+        buildorder: 4
+      perl-Tie-IxHash:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Tie-IxHash
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Tie-IxHash
+        ref: f26
+        buildorder: 4
+      perl-Time-HiRes:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Time-HiRes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Time-HiRes
+        ref: f26
+        buildorder: 4
+      perl-Time-Local:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Time-Local
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Time-Local
+        ref: f26
+        buildorder: 4
+      perl-TimeDate:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-TimeDate
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-TimeDate
+        ref: f26
+        buildorder: 4
+      perl-Try-Tiny:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Try-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Try-Tiny
+        ref: f26
+        buildorder: 11
+      perl-URI:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-URI
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-URI
+        ref: f26
+        buildorder: 4
+      perl-Unicode-Collate:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Unicode-Collate
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Unicode-Collate
+        ref: f26
+        buildorder: 4
+      perl-Unicode-Normalize:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Unicode-Normalize
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Unicode-Normalize
+        ref: f26
+        buildorder: 4
+      perl-YAML:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-YAML
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-YAML
+        ref: f26
+        buildorder: 4
+      perl-YAML-Syck:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-YAML-Syck
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-YAML-Syck
+        ref: f26
+        buildorder: 8
+      perl-accessors:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-accessors
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-accessors
+        ref: f26
+        buildorder: 6
+      perl-autodie:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-autodie
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-autodie
+        ref: f26
+        buildorder: 4
+      perl-bignum:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-bignum
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-bignum
+        ref: f26
+        buildorder: 5
+      perl-constant:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-constant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-constant
+        ref: f26
+        buildorder: 4
+      perl-experimental:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-experimental
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-experimental
+        ref: f26
+        buildorder: 4
+      perl-generators:
+        rationale: RPM dependency generator.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-generators
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-generators
+        ref: f26
+        buildorder: 3
+      perl-inc-latest:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-inc-latest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-inc-latest
+        ref: f26
+        buildorder: 4
+      perl-libnet:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-libnet
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-libnet
+        ref: f26
+        buildorder: 4
+      perl-local-lib:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-local-lib
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-local-lib
+        ref: f26
+        buildorder: 6
+      perl-parent:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-parent
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-parent
+        ref: f26
+        buildorder: 4
+      perl-perlfaq:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-perlfaq
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-perlfaq
+        ref: f26
+        buildorder: 4
+      perl-podlators:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-podlators
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-podlators
+        ref: f26
+        buildorder: 4
+      perl-threads:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-threads
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-threads
+        ref: f26
+        buildorder: 4
+      perl-threads-shared:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-threads-shared
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-threads-shared
+        ref: f26
+        buildorder: 4
+      perl-version:
+        rationale: build dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-version
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-version
+        ref: f26
+        buildorder: 4
+  artifacts:
+    rpms:
+    - perl-4:5.24.4-397.module_1677+5adff7e0.x86_64
+    - perl-Algorithm-Diff-0:1.1903-6.module_1677+5adff7e0.noarch
+    - perl-Archive-Tar-0:2.04-397.module_1677+5adff7e0.noarch
+    - perl-Archive-Tar-0:2.26-1.module_1677+5adff7e0.noarch
+    - perl-Archive-Zip-0:1.59-3.module_1677+5adff7e0.noarch
+    - perl-Attribute-Handlers-0:0.99-397.module_1677+5adff7e0.noarch
+    - perl-Authen-SASL-0:2.16-9.module_1677+5adff7e0.noarch
+    - perl-B-Debug-0:1.23-397.module_1677+5adff7e0.noarch
+    - perl-B-Debug-0:1.24-2.module_1677+5adff7e0.noarch
+    - perl-BSD-Resource-0:1.291.100-1.module_1677+5adff7e0.x86_64
+    - perl-CGI-0:4.36-1.module_1677+5adff7e0.noarch
+    - perl-CPAN-0:2.11-397.module_1677+5adff7e0.noarch
+    - perl-CPAN-0:2.16-1.module_1677+5adff7e0.noarch
+    - perl-CPAN-Meta-0:2.150005-397.module_1677+5adff7e0.noarch
+    - perl-CPAN-Meta-0:2.150010-2.module_1677+5adff7e0.noarch
+    - perl-CPAN-Meta-Check-0:0.014-2.module_1677+5adff7e0.noarch
+    - perl-CPAN-Meta-Requirements-0:2.132-397.module_1677+5adff7e0.noarch
+    - perl-CPAN-Meta-Requirements-0:2.140-7.module_1677+5adff7e0.noarch
+    - perl-CPAN-Meta-YAML-0:0.018-367.module_1677+5adff7e0.noarch
+    - perl-CPAN-Meta-YAML-0:0.018-397.module_1677+5adff7e0.noarch
+    - perl-Capture-Tiny-0:0.46-1.module_1677+5adff7e0.noarch
+    - perl-Carp-0:1.40-366.module_1677+5adff7e0.noarch
+    - perl-Carp-0:1.40-397.module_1677+5adff7e0.noarch
+    - perl-Class-XSAccessor-0:1.19-10.module_1677+5adff7e0.x86_64
+    - perl-Compress-Bzip2-0:2.26-1.module_1677+5adff7e0.x86_64
+    - perl-Compress-Raw-Bzip2-0:2.069-397.module_1677+5adff7e0.x86_64
+    - perl-Compress-Raw-Bzip2-0:2.074-1.module_1677+5adff7e0.x86_64
+    - perl-Compress-Raw-Zlib-0:2.069-397.module_1677+5adff7e0.x86_64
+    - perl-Compress-Raw-Zlib-0:2.074-1.module_1677+5adff7e0.x86_64
+    - perl-Config-Perl-V-0:0.25-397.module_1677+5adff7e0.noarch
+    - perl-Config-Perl-V-0:0.27-2.module_1677+5adff7e0.noarch
+    - perl-DB_File-0:1.835-397.module_1677+5adff7e0.x86_64
+    - perl-DB_File-0:1.841-1.module_1677+5adff7e0.x86_64
+    - perl-Data-Dumper-0:2.160-397.module_1677+5adff7e0.x86_64
+    - perl-Data-Dumper-0:2.161-4.module_1677+5adff7e0.x86_64
+    - perl-Data-OptList-0:0.110-3.module_1677+5adff7e0.noarch
+    - perl-Data-Section-0:0.200006-8.module_1677+5adff7e0.noarch
+    - perl-Devel-Leak-0:0.03-32.module_1677+5adff7e0.x86_64
+    - perl-Devel-PPPort-0:3.32-397.module_1677+5adff7e0.x86_64
+    - perl-Devel-PPPort-0:3.36-1.module_1677+5adff7e0.x86_64
+    - perl-Devel-Peek-0:1.23-397.module_1677+5adff7e0.x86_64
+    - perl-Devel-SelfStubber-0:1.05-397.module_1677+5adff7e0.noarch
+    - perl-Devel-Size-0:0.81-1.module_1677+5adff7e0.x86_64
+    - perl-Devel-StackTrace-1:2.03-1.module_1677+5adff7e0.noarch
+    - perl-Devel-Symdump-1:2.18-1.module_1677+5adff7e0.noarch
+    - perl-Digest-0:1.17-367.module_1677+5adff7e0.noarch
+    - perl-Digest-0:1.17-397.module_1677+5adff7e0.noarch
+    - perl-Digest-HMAC-0:1.03-14.module_1677+5adff7e0.noarch
+    - perl-Digest-MD5-0:2.54-397.module_1677+5adff7e0.x86_64
+    - perl-Digest-MD5-0:2.55-3.module_1677+5adff7e0.x86_64
+    - perl-Digest-SHA-1:5.95-397.module_1677+5adff7e0.x86_64
+    - perl-Digest-SHA-1:6.01-1.module_1677+5adff7e0.x86_64
+    - perl-Digest-SHA1-0:2.13-19.module_1677+5adff7e0.x86_64
+    - perl-Encode-4:2.80-397.module_1677+5adff7e0.x86_64
+    - perl-Encode-4:2.88-6.module_1677+5adff7e0.x86_64
+    - perl-Encode-Locale-0:1.05-6.module_1677+5adff7e0.noarch
+    - perl-Encode-devel-4:2.80-397.module_1677+5adff7e0.noarch
+    - perl-Encode-devel-4:2.88-6.module_1677+5adff7e0.x86_64
+    - perl-Env-0:1.04-366.module_1677+5adff7e0.noarch
+    - perl-Env-0:1.04-397.module_1677+5adff7e0.noarch
+    - perl-Errno-0:1.25-397.module_1677+5adff7e0.x86_64
+    - perl-Expect-0:1.35-1.module_1677+5adff7e0.noarch
+    - perl-Exporter-0:5.72-367.module_1677+5adff7e0.noarch
+    - perl-Exporter-0:5.72-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-CBuilder-1:0.280225-366.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-CBuilder-1:0.280225-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-Command-0:7.10-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-Command-0:7.24-3.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-Embed-0:1.33-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-Install-0:2.04-367.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-Install-0:2.04-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-MM-Utils-0:7.11-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-MM-Utils-0:7.24-3.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-MakeMaker-0:7.10-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-MakeMaker-0:7.24-3.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-Manifest-0:1.70-366.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-Manifest-0:1.70-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-Miniperl-0:1.05-397.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-ParseXS-1:3.31-368.module_1677+5adff7e0.noarch
+    - perl-ExtUtils-ParseXS-1:3.31-397.module_1677+5adff7e0.noarch
+    - perl-Fedora-VSP-0:0.001-5.module_1677+5adff7e0.noarch
+    - perl-File-Fetch-0:0.48-397.module_1677+5adff7e0.noarch
+    - perl-File-Fetch-0:0.56-1.module_1677+5adff7e0.noarch
+    - perl-File-Find-Object-0:0.3.2-2.module_1677+5adff7e0.noarch
+    - perl-File-Find-Object-Rule-0:0.0306-2.module_1677+5adff7e0.noarch
+    - perl-File-Find-Rule-0:0.34-5.module_1677+5adff7e0.noarch
+    - perl-File-Find-Rule-Perl-0:1.15-7.module_1677+5adff7e0.noarch
+    - perl-File-HomeDir-0:1.00-13.module_1677+5adff7e0.noarch
+    - perl-File-Path-0:2.12-367.module_1677+5adff7e0.noarch
+    - perl-File-Path-0:2.12-397.module_1677+5adff7e0.noarch
+    - perl-File-Slurp-Tiny-0:0.004-4.module_1677+5adff7e0.noarch
+    - perl-File-Temp-0:0.230.400-2.module_1677+5adff7e0.noarch
+    - perl-File-Temp-0:0.230.400-397.module_1677+5adff7e0.noarch
+    - perl-File-Which-0:1.21-3.module_1677+5adff7e0.noarch
+    - perl-Filter-2:1.55-397.module_1677+5adff7e0.x86_64
+    - perl-Filter-2:1.58-1.module_1677+5adff7e0.x86_64
+    - perl-Filter-Simple-0:0.92-366.module_1677+5adff7e0.noarch
+    - perl-Filter-Simple-0:0.92-397.module_1677+5adff7e0.noarch
+    - perl-GSSAPI-0:0.28-18.module_1677+5adff7e0.x86_64
+    - perl-Getopt-Long-0:2.48-397.module_1677+5adff7e0.noarch
+    - perl-Getopt-Long-0:2.49.1-2.module_1677+5adff7e0.noarch
+    - perl-HTML-Parser-0:3.72-5.module_1677+5adff7e0.x86_64
+    - perl-HTML-Parser-tests-0:3.72-5.module_1677+5adff7e0.x86_64
+    - perl-HTML-Tagset-0:3.20-28.module_1677+5adff7e0.noarch
+    - perl-HTTP-Date-0:6.02-15.module_1677+5adff7e0.noarch
+    - perl-HTTP-Message-0:6.11-4.module_1677+5adff7e0.noarch
+    - perl-HTTP-Tiny-0:0.056-397.module_1677+5adff7e0.noarch
+    - perl-HTTP-Tiny-0:0.070-2.module_1677+5adff7e0.noarch
+    - perl-IO-0:1.36-397.module_1677+5adff7e0.x86_64
+    - perl-IO-Compress-0:2.069-397.module_1677+5adff7e0.noarch
+    - perl-IO-Compress-0:2.074-1.module_1677+5adff7e0.noarch
+    - perl-IO-HTML-0:1.001-7.module_1677+5adff7e0.noarch
+    - perl-IO-Socket-INET6-0:2.72-9.module_1677+5adff7e0.noarch
+    - perl-IO-Socket-IP-0:0.37-397.module_1677+5adff7e0.noarch
+    - perl-IO-Socket-IP-0:0.39-1.module_1677+5adff7e0.noarch
+    - perl-IO-Socket-SSL-0:2.049-1.module_1677+5adff7e0.noarch
+    - perl-IO-String-0:1.08-28.module_1677+5adff7e0.noarch
+    - perl-IO-Tty-0:1.12-7.module_1677+5adff7e0.x86_64
+    - perl-IO-Zlib-1:1.10-397.module_1677+5adff7e0.noarch
+    - perl-IPC-Cmd-1:0.92-397.module_1677+5adff7e0.noarch
+    - perl-IPC-Cmd-1:0.98-1.module_1677+5adff7e0.noarch
+    - perl-IPC-Run-0:0.96-1.module_1677+5adff7e0.noarch
+    - perl-IPC-SysV-0:2.06-397.module_1677+5adff7e0.x86_64
+    - perl-IPC-SysV-0:2.07-4.module_1677+5adff7e0.x86_64
+    - perl-IPC-System-Simple-0:1.25-12.module_1677+5adff7e0.noarch
+    - perl-Import-Into-0:1.002005-4.module_1677+5adff7e0.noarch
+    - perl-JSON-0:2.90-8.module_1677+5adff7e0.noarch
+    - perl-JSON-PP-0:2.27300-397.module_1677+5adff7e0.noarch
+    - perl-JSON-PP-0:2.94000-1.module_1677+5adff7e0.noarch
+    - perl-JSON-tests-0:2.90-8.module_1677+5adff7e0.noarch
+    - perl-LWP-MediaTypes-0:6.02-11.module_1677+5adff7e0.noarch
+    - perl-Locale-Codes-0:3.25-397.module_1677+5adff7e0.noarch
+    - perl-Locale-Codes-0:3.42-2.module_1677+5adff7e0.noarch
+    - perl-Locale-Maketext-0:1.26-397.module_1677+5adff7e0.noarch
+    - perl-Locale-Maketext-0:1.28-2.module_1677+5adff7e0.noarch
+    - perl-Locale-Maketext-Simple-1:0.21-397.module_1677+5adff7e0.noarch
+    - perl-MIME-Base64-0:3.15-366.module_1677+5adff7e0.x86_64
+    - perl-MIME-Base64-0:3.15-397.module_1677+5adff7e0.x86_64
+    - perl-MRO-Compat-0:0.13-1.module_1677+5adff7e0.noarch
+    - perl-Math-BigInt-0:1.9997.15-397.module_1677+5adff7e0.noarch
+    - perl-Math-BigInt-0:1.9998.11-1.module_1677+5adff7e0.noarch
+    - perl-Math-BigInt-FastCalc-0:0.400-397.module_1677+5adff7e0.x86_64
+    - perl-Math-BigInt-FastCalc-0:0.500.600-2.module_1677+5adff7e0.x86_64
+    - perl-Math-BigRat-0:0.2608.02-397.module_1677+5adff7e0.noarch
+    - perl-Math-BigRat-0:0.2613-1.module_1677+5adff7e0.noarch
+    - perl-Math-Complex-0:1.59-397.module_1677+5adff7e0.noarch
+    - perl-Memoize-0:1.03-397.module_1677+5adff7e0.noarch
+    - perl-Mixin-Linewise-0:0.108-6.module_1677+5adff7e0.noarch
+    - perl-Module-Build-2:0.42.24-1.module_1677+5adff7e0.noarch
+    - perl-Module-CoreList-1:5.20180414-1.module_1677+5adff7e0.noarch
+    - perl-Module-CoreList-1:5.20180414-397.module_1677+5adff7e0.noarch
+    - perl-Module-CoreList-tools-1:5.20180414-1.module_1677+5adff7e0.noarch
+    - perl-Module-CoreList-tools-1:5.20180414-397.module_1677+5adff7e0.noarch
+    - perl-Module-Load-1:0.32-366.module_1677+5adff7e0.noarch
+    - perl-Module-Load-1:0.32-397.module_1677+5adff7e0.noarch
+    - perl-Module-Load-Conditional-0:0.64-397.module_1677+5adff7e0.noarch
+    - perl-Module-Load-Conditional-0:0.68-2.module_1677+5adff7e0.noarch
+    - perl-Module-Loaded-1:0.08-397.module_1677+5adff7e0.noarch
+    - perl-Module-Metadata-0:1.000031-397.module_1677+5adff7e0.noarch
+    - perl-Module-Metadata-0:1.000033-2.module_1677+5adff7e0.noarch
+    - perl-Module-Runtime-0:0.015-1.module_1677+5adff7e0.noarch
+    - perl-Net-IDN-Encode-0:2.400-2.module_1677+5adff7e0.x86_64
+    - perl-Net-LibIDN-0:0.12-25.module_1677+5adff7e0.x86_64
+    - perl-Net-Ping-0:2.43-397.module_1677+5adff7e0.noarch
+    - perl-Net-SSLeay-0:1.81-1.module_1677+5adff7e0.x86_64
+    - perl-Number-Compare-0:0.03-16.module_1677+5adff7e0.noarch
+    - perl-Package-Generator-0:1.106-8.module_1677+5adff7e0.noarch
+    - perl-Params-Check-1:0.38-366.module_1677+5adff7e0.noarch
+    - perl-Params-Check-1:0.38-397.module_1677+5adff7e0.noarch
+    - perl-Params-Util-0:1.07-17.module_1677+5adff7e0.x86_64
+    - perl-Parse-CPAN-Meta-1:1.4417-397.module_1677+5adff7e0.noarch
+    - perl-PathTools-0:3.63-367.module_1677+5adff7e0.x86_64
+    - perl-PathTools-0:3.63-397.module_1677+5adff7e0.x86_64
+    - perl-Perl-OSType-0:1.009-397.module_1677+5adff7e0.noarch
+    - perl-Perl-OSType-0:1.010-4.module_1677+5adff7e0.noarch
+    - perl-Perl-Version-0:1.013-6.module_1677+5adff7e0.noarch
+    - perl-PerlIO-utf8_strict-0:0.007-1.module_1677+5adff7e0.x86_64
+    - perl-PerlIO-via-QuotedPrint-0:0.08-366.module_1677+5adff7e0.noarch
+    - perl-PerlIO-via-QuotedPrint-0:0.08-397.module_1677+5adff7e0.noarch
+    - perl-Pod-Checker-4:1.60-397.module_1677+5adff7e0.noarch
+    - perl-Pod-Checker-4:1.73-2.module_1677+5adff7e0.noarch
+    - perl-Pod-Coverage-0:0.23-11.module_1677+5adff7e0.noarch
+    - perl-Pod-Coverage-TrustPod-0:0.100003-6.module_1677+5adff7e0.noarch
+    - perl-Pod-Escapes-1:1.07-366.module_1677+5adff7e0.noarch
+    - perl-Pod-Escapes-1:1.07-397.module_1677+5adff7e0.noarch
+    - perl-Pod-Eventual-0:0.094001-6.module_1677+5adff7e0.noarch
+    - perl-Pod-Html-0:1.22.01-397.module_1677+5adff7e0.noarch
+    - perl-Pod-Parser-0:1.63-367.module_1677+5adff7e0.noarch
+    - perl-Pod-Parser-0:1.63-397.module_1677+5adff7e0.noarch
+    - perl-Pod-Perldoc-0:3.25-397.module_1677+5adff7e0.noarch
+    - perl-Pod-Perldoc-0:3.28-2.module_1677+5adff7e0.noarch
+    - perl-Pod-Simple-1:3.32-397.module_1677+5adff7e0.noarch
+    - perl-Pod-Simple-1:3.35-2.module_1677+5adff7e0.noarch
+    - perl-Pod-Usage-4:1.68-397.module_1677+5adff7e0.noarch
+    - perl-Pod-Usage-4:1.69-2.module_1677+5adff7e0.noarch
+    - perl-SUPER-0:1.20141117-7.module_1677+5adff7e0.noarch
+    - perl-Scalar-List-Utils-3:1.42-397.module_1677+5adff7e0.x86_64
+    - perl-Scalar-List-Utils-3:1.48-1.module_1677+5adff7e0.x86_64
+    - perl-SelfLoader-0:1.23-397.module_1677+5adff7e0.noarch
+    - perl-Socket-4:2.020-397.module_1677+5adff7e0.x86_64
+    - perl-Socket-4:2.027-1.module_1677+5adff7e0.x86_64
+    - perl-Socket6-0:0.28-2.module_1677+5adff7e0.x86_64
+    - perl-Software-License-0:0.103012-4.module_1677+5adff7e0.noarch
+    - perl-Sort-Versions-0:1.62-5.module_1677+5adff7e0.noarch
+    - perl-Storable-1:2.56-368.module_1677+5adff7e0.x86_64
+    - perl-Storable-1:2.56-397.module_1677+5adff7e0.x86_64
+    - perl-Sub-Exporter-0:0.987-11.module_1677+5adff7e0.noarch
+    - perl-Sub-Identify-0:0.14-1.module_1677+5adff7e0.x86_64
+    - perl-Sub-Install-0:0.928-10.module_1677+5adff7e0.noarch
+    - perl-Sub-Uplevel-1:0.2800-1.module_1677+5adff7e0.noarch
+    - perl-Sys-Syslog-0:0.33-397.module_1677+5adff7e0.x86_64
+    - perl-Sys-Syslog-0:0.35-2.module_1677+5adff7e0.x86_64
+    - perl-Term-ANSIColor-0:4.04-397.module_1677+5adff7e0.noarch
+    - perl-Term-ANSIColor-0:4.06-2.module_1677+5adff7e0.noarch
+    - perl-Term-Cap-0:1.17-366.module_1677+5adff7e0.noarch
+    - perl-Term-Cap-0:1.17-397.module_1677+5adff7e0.noarch
+    - perl-TermReadKey-0:2.37-2.module_1677+5adff7e0.x86_64
+    - perl-Test-0:1.28-397.module_1677+5adff7e0.noarch
+    - perl-Test-CPAN-Meta-0:0.25-8.module_1677+5adff7e0.noarch
+    - perl-Test-Deep-0:1.127-1.module_1677+5adff7e0.noarch
+    - perl-Test-Exception-0:0.43-4.module_1677+5adff7e0.noarch
+    - perl-Test-FailWarnings-0:0.008-9.module_1677+5adff7e0.noarch
+    - perl-Test-Harness-0:3.36-397.module_1677+5adff7e0.noarch
+    - perl-Test-Harness-0:3.42-1.module_1677+5adff7e0.noarch
+    - perl-Test-MockModule-0:0.11-4.module_1677+5adff7e0.noarch
+    - perl-Test-NoWarnings-0:1.04-11.module_1677+5adff7e0.noarch
+    - perl-Test-Output-0:1.03-8.module_1677+5adff7e0.noarch
+    - perl-Test-Pod-0:1.51-5.module_1677+5adff7e0.noarch
+    - perl-Test-Pod-Coverage-0:1.10-7.module_1677+5adff7e0.noarch
+    - perl-Test-Portability-Files-0:0.07-2.module_1677+5adff7e0.noarch
+    - perl-Test-Simple-0:1.001014-397.module_1677+5adff7e0.noarch
+    - perl-Test-Simple-1:1.302086-1.module_1677+5adff7e0.noarch
+    - perl-Test-Taint-0:1.06-15.module_1677+5adff7e0.x86_64
+    - perl-Test-TrailingSpace-0:0.0301-2.module_1677+5adff7e0.noarch
+    - perl-Test-Version-0:2.05-2.module_1677+5adff7e0.noarch
+    - perl-Test-Warn-0:0.32-2.module_1677+5adff7e0.noarch
+    - perl-Text-Balanced-0:2.03-366.module_1677+5adff7e0.noarch
+    - perl-Text-Balanced-0:2.03-397.module_1677+5adff7e0.noarch
+    - perl-Text-Diff-0:1.44-3.module_1677+5adff7e0.noarch
+    - perl-Text-Glob-0:0.11-1.module_1677+5adff7e0.noarch
+    - perl-Text-Levenshtein-Damerau-XS-0:3.2-1.module_1677+5adff7e0.x86_64
+    - perl-Text-ParseWords-0:3.30-366.module_1677+5adff7e0.noarch
+    - perl-Text-ParseWords-0:3.30-397.module_1677+5adff7e0.noarch
+    - perl-Text-Tabs+Wrap-0:2013.0523-366.module_1677+5adff7e0.noarch
+    - perl-Text-Tabs+Wrap-0:2013.0523-397.module_1677+5adff7e0.noarch
+    - perl-Text-Template-0:1.47-1.module_1677+5adff7e0.noarch
+    - perl-Thread-Queue-0:3.09-397.module_1677+5adff7e0.noarch
+    - perl-Thread-Queue-0:3.12-1.module_1677+5adff7e0.noarch
+    - perl-Tie-IxHash-0:1.23-8.module_1677+5adff7e0.noarch
+    - perl-Time-HiRes-0:1.9741-397.module_1677+5adff7e0.x86_64
+    - perl-Time-HiRes-0:1.9753-1.module_1677+5adff7e0.x86_64
+    - perl-Time-Local-0:1.2300-397.module_1677+5adff7e0.noarch
+    - perl-Time-Local-1:1.250-2.module_1677+5adff7e0.noarch
+    - perl-Time-Piece-0:1.31-397.module_1677+5adff7e0.x86_64
+    - perl-TimeDate-1:2.30-10.module_1677+5adff7e0.noarch
+    - perl-Try-Tiny-0:0.28-2.module_1677+5adff7e0.noarch
+    - perl-URI-0:1.71-6.module_1677+5adff7e0.noarch
+    - perl-Unicode-Collate-0:1.14-397.module_1677+5adff7e0.x86_64
+    - perl-Unicode-Collate-0:1.20-1.module_1677+5adff7e0.x86_64
+    - perl-Unicode-Normalize-0:1.25-366.module_1677+5adff7e0.x86_64
+    - perl-Unicode-Normalize-0:1.25-397.module_1677+5adff7e0.x86_64
+    - perl-YAML-0:1.23-1.module_1677+5adff7e0.noarch
+    - perl-YAML-Syck-0:1.30-1.module_1677+5adff7e0.x86_64
+    - perl-accessors-0:1.01-21.module_1677+5adff7e0.noarch
+    - perl-autodie-0:2.29-367.module_1677+5adff7e0.noarch
+    - perl-autodie-0:2.29-397.module_1677+5adff7e0.noarch
+    - perl-bignum-0:0.42-397.module_1677+5adff7e0.noarch
+    - perl-bignum-0:0.49-1.module_1677+5adff7e0.noarch
+    - perl-constant-0:1.33-368.module_1677+5adff7e0.noarch
+    - perl-constant-0:1.33-397.module_1677+5adff7e0.noarch
+    - perl-core-0:5.24.4-397.module_1677+5adff7e0.x86_64
+    - perl-devel-4:5.24.4-397.module_1677+5adff7e0.x86_64
+    - perl-encoding-4:2.17-397.module_1677+5adff7e0.x86_64
+    - perl-encoding-4:2.19-6.module_1677+5adff7e0.x86_64
+    - perl-experimental-0:0.016-397.module_1677+5adff7e0.noarch
+    - perl-experimental-0:0.019-1.module_1677+5adff7e0.noarch
+    - perl-generators-0:1.10-2.module_1677+5adff7e0.noarch
+    - perl-homedir-0:2.000023-1.module_1677+5adff7e0.noarch
+    - perl-inc-latest-2:0.500-6.module_1677+5adff7e0.noarch
+    - perl-libnet-0:3.08-397.module_1677+5adff7e0.noarch
+    - perl-libnet-0:3.11-1.module_1677+5adff7e0.noarch
+    - perl-libnetcfg-4:5.24.4-397.module_1677+5adff7e0.noarch
+    - perl-libs-4:5.24.4-397.module_1677+5adff7e0.x86_64
+    - perl-local-lib-0:2.000023-1.module_1677+5adff7e0.noarch
+    - perl-macros-4:5.24.4-397.module_1677+5adff7e0.x86_64
+    - perl-open-0:1.10-397.module_1677+5adff7e0.noarch
+    - perl-parent-1:0.234-397.module_1677+5adff7e0.noarch
+    - perl-parent-1:0.236-2.module_1677+5adff7e0.noarch
+    - perl-perlfaq-0:5.021010-397.module_1677+5adff7e0.noarch
+    - perl-perlfaq-0:5.021011-3.module_1677+5adff7e0.noarch
+    - perl-podlators-0:4.07-397.module_1677+5adff7e0.noarch
+    - perl-podlators-0:4.09-3.module_1677+5adff7e0.noarch
+    - perl-tests-4:5.24.4-397.module_1677+5adff7e0.x86_64
+    - perl-threads-1:2.07-397.module_1677+5adff7e0.x86_64
+    - perl-threads-1:2.21-1.module_1677+5adff7e0.x86_64
+    - perl-threads-shared-0:1.51-397.module_1677+5adff7e0.x86_64
+    - perl-threads-shared-0:1.58-1.module_1677+5adff7e0.x86_64
+    - perl-utils-0:5.24.4-397.module_1677+5adff7e0.noarch
+    - perl-version-5:0.99.16-397.module_1677+5adff7e0.noarch
+    - perl-version-5:0.99.18-1.module_1677+5adff7e0.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: perl
+  stream: 5.26
+  version: 20180417112647
+  context: ccbeb30a
+  arch: x86_64
+  summary: Practical Extraction and Report Language
+  description: >
+    Perl is a high-level programming language with roots in C, sed, awk and shell
+    scripting. Perl is good at handling processes and files, and is especially good
+    at handling text. Perl's hallmarks are practicality and efficiency. While it is
+    used to do a lot of different things, Perl's most common applications are system
+    administration utilities and web programming.
+  license:
+    module:
+    - MIT
+    content:
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic) and BSD and Public Domain and UCD
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic) and MIT
+    - (GPL+ or Artistic) and Artistic 2.0 and UCD
+    - (GPL+ or Artistic) and BSD
+    - (GPL+ or Artistic) and CC0 and Public Domain
+    - (GPL+ or Artistic) and HSLR and MIT and UCD
+    - (GPL+ or Artistic) and MIT
+    - (GPL+ or Artistic) and Public Domain
+    - (GPL+ or Artistic) and UCD
+    - (GPL+ or Artistic) and Unicode
+    - (GPL+ or Artistic) and zlib
+    - ASL 2.0
+    - GPL+
+    - GPL+ or Artistic
+    - GPLv2+ or Artistic
+    - GPLv3+
+    - MIT
+    - TTWL
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/perl.git?#b7ea70e535667def6fb4258d744d47a0f0972661
+      commit: b7ea70e535667def6fb4258d744d47a0f0972661
+      buildrequires:
+        perl-bootstrap:
+          ref: 22773d9e44948febd267fc7b94e169b1c7e81f73
+          stream: 5.26
+          context: 6c81f848
+          version: 20180417064707
+          filtered_rpms: []
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        perl-Text-Diff:
+          ref: 435597b4b8f23cdb4b5d08a83526f3a0ba180ba4
+        perl-Text-Balanced:
+          ref: 8c14f0f727543b80dc9cacba0422bcc1653d0290
+        perl-File-Fetch:
+          ref: 7e786fd7e77fd794553f84ff29dc777cd9f73ca2
+        perl:
+          ref: feb15b2a5274ffede0261170972b96d61acc9b38
+        perl-Math-BigRat:
+          ref: 8d926e35aeb4d768c2a9e9c9f2d24e36202b8e2d
+        perl-Math-BigInt-FastCalc:
+          ref: fd294a4d494055cd4f3f7e22f0f0c361162dedfa
+        perl-Locale-Maketext:
+          ref: 6dd172c644c44c07b1613b0870a119ee5e6d4116
+        perl-Algorithm-Diff:
+          ref: b572ed3bbdd7421c4ec31da90602f12f7a8c951c
+        perl-PathTools:
+          ref: a0ed8e15339741624d99094a261ecef2f2bef816
+        perl-IPC-System-Simple:
+          ref: 5b4319c5aabf7945208163c339c112b68b40d36a
+        perl-CPAN-Meta-Requirements:
+          ref: f25cbf2508f08dcb618b5e097cda6023aea94101
+        perl-Compress-Bzip2:
+          ref: 4ca6f6001d529639ad9af34f6a4829371ed7c88c
+        perl-IO-Compress:
+          ref: bb10d2103bf534e10a4a1d1bc987a4314cb5de48
+        perl-threads-shared:
+          ref: 236010203776860d682ee2e6d37529e8e4aaa90a
+        perl-autodie:
+          ref: 08926569224919ffa066397ca80c5b1818a89e90
+        perl-constant:
+          ref: bce81fc9c982eeee92490116718ab9ed652eb0e7
+        perl-bignum:
+          ref: e1753ef99cc972644a0a217e676467b8fd5d5788
+        perl-Params-Check:
+          ref: 94989a67e37e22221a55b1d39dfb9f804122f928
+        perl-Archive-Zip:
+          ref: 6270e0a0fe7c56198441d0e8757500f56a4a54a2
+        perl-Math-BigInt:
+          ref: 76c86fadeda569a2ebd6439f12e7f69f74c8df67
+        perl-podlators:
+          ref: 49c1364c8485ff979a2ccded759739a47e164836
+        perl-ExtUtils-Manifest:
+          ref: f1169d7bb27bfb1b2db567be1f0ff112a9069246
+        perl-Compress-Raw-Zlib:
+          ref: c9d37e07af93fe0a5e4886536b27f016260074ca
+        perl-local-lib:
+          ref: 0716ed7be631222c11ec33672373662daa6b00bf
+        perl-libnet:
+          ref: 8799d71bc96c9db7a72658edcd27f9f21b260f71
+        perl-B-Debug:
+          ref: 5a7c0b7619476154ff3129fe449afabb1b450279
+        perl-Config-Perl-V:
+          ref: 8d5189f0c6816a5ff74a20ba7426d3964aa626aa
+        perl-threads:
+          ref: 96ef6a4161926a852227a37db2a82769df38ebc5
+        perl-Term-Cap:
+          ref: 1d444a86d772b87c5b0484e3639f7bac52de8afe
+        perl-Unicode-Normalize:
+          ref: c7a4b3f134e101eb452b949eeda6497d6ea9e520
+        perl-Storable:
+          ref: b34d556aadded8e2f5c62894dbbcd0fae9d3ab87
+        perl-IPC-SysV:
+          ref: 4cf56fbde1b8a369fb6114d0f2dc7866dd835b71
+        perl-IPC-Cmd:
+          ref: 9600d4d856fa56cd63d78d51b1ab699556bbaa20
+        perl-Time-HiRes:
+          ref: 400def5c2f8c642b692a22c7a6f45da6f4cbd868
+        perl-Digest-MD5:
+          ref: 8fad912c493bc960566e5ce7118e0cdce3b9a769
+        perl-Getopt-Long:
+          ref: 3fcd385e78c21d29488f8e020e2b9df21c54900f
+        perl-Module-Metadata:
+          ref: 1578659d3194251b91e39887baf3ad56689fad90
+        perl-version:
+          ref: 72cca25da1658f759319b46edc9d5abf7b35c3f2
+        perl-Devel-Size:
+          ref: 960a461ee17d9a34e9817a771410dd2801be2f17
+        perl-Unicode-Collate:
+          ref: 3a0555a1c080f2bba8e052c32ce35d4c1fca429a
+        perl-Env:
+          ref: 201efc08b7115ab13b1402f76ed05e5c8ed686d4
+        perl-ExtUtils-MakeMaker:
+          ref: c88d4cf08d3e3ddc8c113a430d287a830c1133e6
+        perl-File-HomeDir:
+          ref: 253a5f4a3d03187c799904441650124e8ec832ea
+        perl-experimental:
+          ref: dd6b54aaedc470ecd8ed9aa2bc5e6b86334c90ff
+        perl-Data-Dumper:
+          ref: 8e85cc7e6166838184b034d875759a39df4d10d3
+        perl-ExtUtils-ParseXS:
+          ref: c84346769c6a5009890661786a061af1e06d32dd
+        perl-Text-Tabs+Wrap:
+          ref: 84d9073a2276ee2310cfc7e633c08e271c2f2319
+        perl-Pod-Perldoc:
+          ref: c582b2f1fb814afe692c9ad44e3ac656505b5183
+        perl-Devel-PPPort:
+          ref: 17c87af74208a53d3202030ad52862fd376123fc
+        perl-CPAN-Meta-YAML:
+          ref: 04a0e2e11487241ed251223755f1abe43bbe392a
+        perl-Pod-Usage:
+          ref: 98983d9f8b961510acff3a1190c7ea62d447699f
+        perl-Fedora-VSP:
+          ref: 90425acf3b0601d4feb86e0339f0c0efdd0435ae
+        perl-CPAN-Meta:
+          ref: f8259dccb36b9a47dc6bad88847c3fcd3563a196
+        perl-File-Path:
+          ref: ac6856f118e7aa9a3a709c6202ab06494ecdd9b3
+        perl-generators:
+          ref: 3517fe526a3f0bb16c097eecd05bfe9dfb94c42e
+        perl-Digest:
+          ref: b3f866352aea430935df7f2f0afaaf3cced7d214
+        perl-Perl-OSType:
+          ref: 7191911473475122ff950ed36748133d8b2f968b
+        perl-Pod-Simple:
+          ref: 05a654f26321267554e75398eb19f704b4b97e17
+        perl-Sub-Install:
+          ref: f3365c2a0b610eb21f6c1c786958c0e8ba08a47c
+        perl-PerlIO-via-QuotedPrint:
+          ref: 7d17de12fac09e63e1c14ed17229c6d23e923830
+        perl-HTTP-Tiny:
+          ref: ccd7e054fc273dbfab16202a35f8fd73219b27c7
+        perl-Text-Template:
+          ref: c3ff74620de07ec5a20b398981cfe60bc23b7533
+        perl-Pod-Parser:
+          ref: 13b1e60337a84241ed263e3a62af46005bec3b8c
+        perl-Pod-Escapes:
+          ref: b86907d1d42dbd25c327e34b09b061f0a3f96d8a
+        perl-Package-Generator:
+          ref: 8a4118f2e4299109b3a7e6e0dea5ee7424e632bf
+        perl-Sys-Syslog:
+          ref: b83dcfb81b92c0617bee60d8ac89d1d228b88d8e
+        perl-Archive-Tar:
+          ref: 1713c34fd47329b8bd3c237822a2a7de75266654
+        perl-Time-Local:
+          ref: 12fcdce59f0b8fd7daeb1b4088a3c7966cc6a302
+        perl-perlfaq:
+          ref: ab3baf6a6ad945423be4696bb7ac0481ce8e9076
+        perl-JSON-PP:
+          ref: 02d427bafed752ddfd755e1cfcd71c4daaa7b336
+        perl-Term-ANSIColor:
+          ref: 7e942843d7f43f5535e55f7709943e210743f4fe
+        perl-MRO-Compat:
+          ref: 7b9d4772b76353d755f44acc9a686e9566a1a4b7
+        perl-Locale-Codes:
+          ref: d7b98d549b08417aaef3c02cd0314e0cda13dddb
+        perl-Test-Harness:
+          ref: 65288c532917fea41328a20520e0755f6eb18463
+        perl-Sub-Exporter:
+          ref: 34cd68b9ccfbae47690795a40a14a236ff0b2319
+        perl-Socket:
+          ref: 20b784e3737e5842c973bd31f1735b67e77b050f
+        perl-Module-CoreList:
+          ref: 6e295ecf1e1dd6a348563ff1563a5f4c53001e71
+        perl-Carp:
+          ref: b853f44fd4ed76815057dbec21b16f8069731630
+        perl-Filter-Simple:
+          ref: 08e79709ade8905bc3212d2c7dbb1d168d578dba
+        perl-Pod-Checker:
+          ref: dd7b179ffb95412b1f28d3b825d87132f391821e
+        perl-Compress-Raw-Bzip2:
+          ref: 2a51171531415b788d4bc6cdd05a823fb4b831b5
+        perl-DB_File:
+          ref: cb750cc628fdf540662b6694fce548ebd4aceff7
+        perl-Filter:
+          ref: 78296ad909c75c445e4c43526e3ae57f25de7c34
+        perl-inc-latest:
+          ref: b94b9e6f144d6ce856e827a2cb9c16c42cce56b5
+        perl-Params-Util:
+          ref: a69abfa9df18bb76b6ccb98caa103795abc5d083
+        perl-Module-Load-Conditional:
+          ref: 532fb21fdf6ff39b29abaccbdc4a1f87941521f2
+        perl-ExtUtils-CBuilder:
+          ref: 4e5e482495a977c28396e2d1149def8dcb12e15f
+        perl-Data-Section:
+          ref: ce79e1d99123d4220543d1eb2d2806673277cad4
+        perl-Scalar-List-Utils:
+          ref: c0ea69a001e7bb2a50a9c122dcc5ce792125f6e4
+        perl-Text-ParseWords:
+          ref: 809c9bd7181b286d5e14e80a73f6ea50ac3b62b3
+        perl-Encode:
+          ref: 5417f768a229062a55dde8f25b5b9aac039f96e1
+        perl-Module-Build:
+          ref: a9f6bbfbfc8303db7b57cbea35e53de61a46a165
+        perl-Thread-Queue:
+          ref: 8c85fbf927199c852e95b3fed93ff28c67b3adaa
+        perl-Exporter:
+          ref: 68f93042fb090750ccc7022bd957fa12ff184ecb
+        perl-Software-License:
+          ref: dbee7688f08ab815650fd845122a8ee8cfb0294c
+        perl-Digest-SHA:
+          ref: e2e8e4441dcace400b4340f2269b218a949234a2
+        perl-File-Temp:
+          ref: 75a5d0eb68e5d261762dbb20412efa17dfeb6ab3
+        perl-URI:
+          ref: 8696c54987665ac968cb66d98b69e49a37a89b52
+        perl-Data-OptList:
+          ref: 55696a188230a0b16e32bc0cc6183cc0683753e3
+        perl-ExtUtils-Install:
+          ref: 5eb9021663b033a695802e5d960795c1b338f1d1
+        perl-MIME-Base64:
+          ref: c099afc6b1d7eec124f46bea88b86a2edd0f7b56
+        perl-Test-Simple:
+          ref: 96c4c3b6c0172748a9a9c95fb2c1fefc9f73ee04
+        perl-File-Which:
+          ref: 0c9cbe3a1d01d42035314f8d5527e6f505142cab
+        perl-CPAN:
+          ref: c91f221d2bbde2992152786a94b3da8899d7a628
+        perl-Text-Glob:
+          ref: b19ed6fe9d0ff70870939d2bfe33e2bd059b732a
+        perl-Module-Load:
+          ref: 4f363f0c7d356591f33a22a930f4501167b01053
+        perl-IO-Socket-IP:
+          ref: 1a65c1170f6582ad9ece8fe9c76c540e18cd3264
+        perl-parent:
+          ref: c3649d1868f869883423867076131c1604fd4467
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/modularity-modules/perl
+    tracker: https://github.com/modularity-modules/perl/issues
+  profiles:
+    default:
+      description: Interpreter and all Perl modules bundled within upstream Perl.
+      rpms:
+      - perl
+    minimal:
+      description: Only the interpreter as a standalone executable.
+      rpms:
+      - perl-interpreter
+  api:
+    rpms:
+    - perl
+    - perl-Archive-Tar
+    - perl-Attribute-Handlers
+    - perl-B-Debug
+    - perl-CPAN
+    - perl-CPAN-Meta
+    - perl-CPAN-Meta-Requirements
+    - perl-CPAN-Meta-YAML
+    - perl-Carp
+    - perl-Compress-Raw-Bzip2
+    - perl-Compress-Raw-Zlib
+    - perl-Config-Perl-V
+    - perl-DB_File
+    - perl-Data-Dumper
+    - perl-Devel-PPPort
+    - perl-Devel-Peek
+    - perl-Devel-SelfStubber
+    - perl-Digest
+    - perl-Digest-MD5
+    - perl-Digest-SHA
+    - perl-Encode
+    - perl-Encode-devel
+    - perl-Env
+    - perl-Errno
+    - perl-Exporter
+    - perl-ExtUtils-CBuilder
+    - perl-ExtUtils-Command
+    - perl-ExtUtils-Embed
+    - perl-ExtUtils-Install
+    - perl-ExtUtils-MM-Utils
+    - perl-ExtUtils-MakeMaker
+    - perl-ExtUtils-Manifest
+    - perl-ExtUtils-Miniperl
+    - perl-ExtUtils-ParseXS
+    - perl-File-Fetch
+    - perl-File-Path
+    - perl-File-Temp
+    - perl-Filter
+    - perl-Filter-Simple
+    - perl-Getopt-Long
+    - perl-HTTP-Tiny
+    - perl-IO
+    - perl-IO-Compress
+    - perl-IO-Socket-IP
+    - perl-IO-Zlib
+    - perl-IPC-Cmd
+    - perl-IPC-SysV
+    - perl-JSON-PP
+    - perl-Locale-Codes
+    - perl-Locale-Maketext
+    - perl-Locale-Maketext-Simple
+    - perl-MIME-Base64
+    - perl-Math-BigInt
+    - perl-Math-BigInt-FastCalc
+    - perl-Math-BigRat
+    - perl-Math-Complex
+    - perl-Memoize
+    - perl-Module-CoreList
+    - perl-Module-CoreList-tools
+    - perl-Module-Load
+    - perl-Module-Load-Conditional
+    - perl-Module-Loaded
+    - perl-Module-Metadata
+    - perl-Net-Ping
+    - perl-Params-Check
+    - perl-PathTools
+    - perl-Perl-OSType
+    - perl-PerlIO-via-QuotedPrint
+    - perl-Pod-Checker
+    - perl-Pod-Escapes
+    - perl-Pod-Html
+    - perl-Pod-Parser
+    - perl-Pod-Perldoc
+    - perl-Pod-Simple
+    - perl-Pod-Usage
+    - perl-Scalar-List-Utils
+    - perl-SelfLoader
+    - perl-Socket
+    - perl-Storable
+    - perl-Sys-Syslog
+    - perl-Term-ANSIColor
+    - perl-Term-Cap
+    - perl-Test
+    - perl-Test-Harness
+    - perl-Test-Simple
+    - perl-Text-Balanced
+    - perl-Text-ParseWords
+    - perl-Text-Tabs+Wrap
+    - perl-Thread-Queue
+    - perl-Time-HiRes
+    - perl-Time-Local
+    - perl-Time-Piece
+    - perl-Unicode-Collate
+    - perl-Unicode-Normalize
+    - perl-autodie
+    - perl-bignum
+    - perl-constant
+    - perl-devel
+    - perl-encoding
+    - perl-experimental
+    - perl-generators
+    - perl-interpreter
+    - perl-libnet
+    - perl-libnetcfg
+    - perl-libs
+    - perl-macros
+    - perl-open
+    - perl-parent
+    - perl-perlfaq
+    - perl-podlators
+    - perl-tests
+    - perl-threads
+    - perl-threads-shared
+    - perl-utils
+    - perl-version
+  buildopts:
+    rpms:
+      macros: |
+        %_with_perl_enables_groff 1
+        %_without_perl_enables_syslog_test 1
+        %_with_perl_enables_systemtap 1
+        %_without_perl_enables_tcsh 1
+        %_without_perl_Compress_Bzip2_enables_optional_test 1
+        %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+        %_without_perl_IPC_System_Simple_enables_optional_test 1
+        %_without_perl_LWP_MediaTypes_enables_mailcap 1
+        %_without_perl_Module_Build_enables_optional_test 1
+        %_without_perl_Perl_OSType_enables_optional_test 1
+        %_without_perl_Pod_Perldoc_enables_tk_test 1
+        %_without_perl_Software_License_enables_optional_test 1
+        %_without_perl_Sys_Syslog_enables_optional_test 1
+        %_without_perl_Test_Harness_enables_optional_test 1
+        %_without_perl_Test_Simple_enables_optional_test 1
+        %_without_perl_URI_enables_Business_ISBN 1
+  components:
+    rpms:
+      perl:
+        rationale: The Perl interpreter.
+        repository: git://pkgs.fedoraproject.org/rpms/perl
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl
+        ref: f28
+      perl-Algorithm-Diff:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Algorithm-Diff
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Algorithm-Diff
+        ref: f28
+      perl-Archive-Tar:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Archive-Tar
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Archive-Tar
+        ref: f28
+      perl-Archive-Zip:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Archive-Zip
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Archive-Zip
+        ref: f28
+      perl-B-Debug:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-B-Debug
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-B-Debug
+        ref: f28
+      perl-CPAN:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN
+        ref: f28
+      perl-CPAN-Meta:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta
+        ref: f28
+      perl-CPAN-Meta-Requirements:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-Requirements
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-Requirements
+        ref: f28
+      perl-CPAN-Meta-YAML:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-YAML
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-YAML
+        ref: f28
+      perl-Carp:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Carp
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Carp
+        ref: f28
+      perl-Compress-Bzip2:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Bzip2
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Bzip2
+        ref: f28
+      perl-Compress-Raw-Bzip2:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Raw-Bzip2
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Raw-Bzip2
+        ref: f28
+      perl-Compress-Raw-Zlib:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Raw-Zlib
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Raw-Zlib
+        ref: f28
+      perl-Config-Perl-V:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Config-Perl-V
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Config-Perl-V
+        ref: f28
+      perl-DB_File:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-DB_File
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-DB_File
+        ref: f28
+      perl-Data-Dumper:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-Dumper
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-Dumper
+        ref: f28
+      perl-Data-OptList:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-OptList
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-OptList
+        ref: f28
+      perl-Data-Section:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-Section
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-Section
+        ref: f28
+      perl-Devel-PPPort:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-PPPort
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-PPPort
+        ref: f28
+      perl-Devel-Size:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-Size
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-Size
+        ref: f28
+      perl-Digest:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest
+        ref: f28
+      perl-Digest-MD5:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-MD5
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-MD5
+        ref: f28
+      perl-Digest-SHA:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-SHA
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-SHA
+        ref: f28
+      perl-Encode:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Encode
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Encode
+        ref: f28
+      perl-Env:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Env
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Env
+        ref: f28
+      perl-Exporter:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Exporter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Exporter
+        ref: f28
+      perl-ExtUtils-CBuilder:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-CBuilder
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-CBuilder
+        ref: f28
+      perl-ExtUtils-Install:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-Install
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-Install
+        ref: f28
+      perl-ExtUtils-MakeMaker:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-MakeMaker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-MakeMaker
+        ref: f28
+      perl-ExtUtils-Manifest:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-Manifest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-Manifest
+        ref: f28
+      perl-ExtUtils-ParseXS:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-ParseXS
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-ParseXS
+        ref: f28
+      perl-Fedora-VSP:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Fedora-VSP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Fedora-VSP
+        ref: f28
+      perl-File-Fetch:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Fetch
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Fetch
+        ref: f28
+      perl-File-HomeDir:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-HomeDir
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-HomeDir
+        ref: f28
+      perl-File-Path:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Path
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Path
+        ref: f28
+      perl-File-Temp:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Temp
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Temp
+        ref: f28
+      perl-File-Which:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Which
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Which
+        ref: f28
+      perl-Filter:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Filter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Filter
+        ref: f28
+      perl-Filter-Simple:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Filter-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Filter-Simple
+        ref: f28
+      perl-Getopt-Long:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Getopt-Long
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Getopt-Long
+        ref: f28
+      perl-HTTP-Tiny:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTTP-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTTP-Tiny
+        ref: f28
+      perl-IO-Compress:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Compress
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Compress
+        ref: f28
+      perl-IO-Socket-IP:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Socket-IP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Socket-IP
+        ref: f28
+      perl-IPC-Cmd:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-Cmd
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-Cmd
+        ref: f28
+      perl-IPC-SysV:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-SysV
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-SysV
+        ref: f28
+      perl-IPC-System-Simple:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-System-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-System-Simple
+        ref: f28
+      perl-JSON-PP:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-JSON-PP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-JSON-PP
+        ref: f28
+      perl-Locale-Codes:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Locale-Codes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Locale-Codes
+        ref: f28
+      perl-Locale-Maketext:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Locale-Maketext
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Locale-Maketext
+        ref: f28
+      perl-MIME-Base64:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-MIME-Base64
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-MIME-Base64
+        ref: f28
+      perl-MRO-Compat:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-MRO-Compat
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-MRO-Compat
+        ref: f28
+      perl-Math-BigInt:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigInt
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigInt
+        ref: f28
+      perl-Math-BigInt-FastCalc:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigInt-FastCalc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigInt-FastCalc
+        ref: f28
+      perl-Math-BigRat:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigRat
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigRat
+        ref: f28
+      perl-Module-Build:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Build
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Build
+        ref: f28
+      perl-Module-CoreList:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-CoreList
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-CoreList
+        ref: f28
+      perl-Module-Load:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Load
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Load
+        ref: f28
+      perl-Module-Load-Conditional:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Load-Conditional
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Load-Conditional
+        ref: f28
+      perl-Module-Metadata:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Metadata
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Metadata
+        ref: f28
+      perl-Package-Generator:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Package-Generator
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Package-Generator
+        ref: f28
+      perl-Params-Check:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Params-Check
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Params-Check
+        ref: f28
+      perl-Params-Util:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Params-Util
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Params-Util
+        ref: f28
+      perl-PathTools:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PathTools
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PathTools
+        ref: f28
+      perl-Perl-OSType:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Perl-OSType
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Perl-OSType
+        ref: f28
+      perl-PerlIO-via-QuotedPrint:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PerlIO-via-QuotedPrint
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PerlIO-via-QuotedPrint
+        ref: f28
+      perl-Pod-Checker:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Checker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Checker
+        ref: f28
+      perl-Pod-Escapes:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Escapes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Escapes
+        ref: f28
+      perl-Pod-Parser:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Parser
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Parser
+        ref: f28
+      perl-Pod-Perldoc:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Perldoc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Perldoc
+        ref: f28
+      perl-Pod-Simple:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Simple
+        ref: f28
+      perl-Pod-Usage:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Usage
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Usage
+        ref: f28
+      perl-Scalar-List-Utils:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Scalar-List-Utils
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Scalar-List-Utils
+        ref: f28
+      perl-Socket:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Socket
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Socket
+        ref: f28
+      perl-Software-License:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Software-License
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Software-License
+        ref: f28
+      perl-Storable:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Storable
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Storable
+        ref: f28
+      perl-Sub-Exporter:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Exporter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Exporter
+        ref: f28
+      perl-Sub-Install:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Install
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Install
+        ref: f28
+      perl-Sys-Syslog:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sys-Syslog
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sys-Syslog
+        ref: f28
+      perl-Term-ANSIColor:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Term-ANSIColor
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Term-ANSIColor
+        ref: f28
+      perl-Term-Cap:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Term-Cap
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Term-Cap
+        ref: f28
+      perl-Test-Harness:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Harness
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Harness
+        ref: f28
+      perl-Test-Simple:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Simple
+        ref: f28
+      perl-Text-Balanced:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Balanced
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Balanced
+        ref: f28
+      perl-Text-Diff:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Diff
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Diff
+        ref: f28
+      perl-Text-Glob:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Glob
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Glob
+        ref: f28
+      perl-Text-ParseWords:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-ParseWords
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-ParseWords
+        ref: f28
+      perl-Text-Tabs+Wrap:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Tabs+Wrap
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Tabs+Wrap
+        ref: f28
+      perl-Text-Template:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Template
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Template
+        ref: f28
+      perl-Thread-Queue:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Thread-Queue
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Thread-Queue
+        ref: f28
+      perl-Time-HiRes:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Time-HiRes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Time-HiRes
+        ref: f28
+      perl-Time-Local:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Time-Local
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Time-Local
+        ref: f28
+      perl-URI:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-URI
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-URI
+        ref: f28
+      perl-Unicode-Collate:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Unicode-Collate
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Unicode-Collate
+        ref: f28
+      perl-Unicode-Normalize:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Unicode-Normalize
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Unicode-Normalize
+        ref: f28
+      perl-autodie:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-autodie
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-autodie
+        ref: f28
+      perl-bignum:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-bignum
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-bignum
+        ref: f28
+      perl-constant:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-constant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-constant
+        ref: f28
+      perl-experimental:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-experimental
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-experimental
+        ref: f28
+      perl-generators:
+        rationale: RPM dependency generator.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-generators
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-generators
+        ref: f28
+      perl-inc-latest:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-inc-latest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-inc-latest
+        ref: f28
+      perl-libnet:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-libnet
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-libnet
+        ref: f28
+      perl-local-lib:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-local-lib
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-local-lib
+        ref: f28
+      perl-parent:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-parent
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-parent
+        ref: f28
+      perl-perlfaq:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-perlfaq
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-perlfaq
+        ref: f28
+      perl-podlators:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-podlators
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-podlators
+        ref: f28
+      perl-threads:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-threads
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-threads
+        ref: f28
+      perl-threads-shared:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-threads-shared
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-threads-shared
+        ref: f28
+      perl-version:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-version
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-version
+        ref: f28
+  artifacts:
+    rpms:
+    - perl-4:5.26.2-410.module_1681+b405d8e2.x86_64
+    - perl-Algorithm-Diff-0:1.1903-9.module_1681+b405d8e2.noarch
+    - perl-Archive-Tar-0:2.26-6.module_1681+b405d8e2.noarch
+    - perl-Archive-Zip-0:1.60-2.module_1681+b405d8e2.noarch
+    - perl-Attribute-Handlers-0:0.99-410.module_1681+b405d8e2.noarch
+    - perl-B-Debug-0:1.26-2.module_1681+b405d8e2.noarch
+    - perl-CPAN-0:2.18-397.module_1681+b405d8e2.noarch
+    - perl-CPAN-Meta-0:2.150010-396.module_1681+b405d8e2.noarch
+    - perl-CPAN-Meta-Requirements-0:2.140-396.module_1681+b405d8e2.noarch
+    - perl-CPAN-Meta-YAML-0:0.018-397.module_1681+b405d8e2.noarch
+    - perl-Carp-0:1.42-395.module_1681+b405d8e2.noarch
+    - perl-Compress-Bzip2-0:2.26-6.module_1681+b405d8e2.x86_64
+    - perl-Compress-Raw-Bzip2-0:2.081-1.module_1681+b405d8e2.x86_64
+    - perl-Compress-Raw-Zlib-0:2.081-1.module_1681+b405d8e2.x86_64
+    - perl-Config-Perl-V-0:0.29-2.module_1681+b405d8e2.noarch
+    - perl-DB_File-0:1.841-1.module_1681+b405d8e2.x86_64
+    - perl-Data-Dumper-0:2.167-399.module_1681+b405d8e2.x86_64
+    - perl-Data-OptList-0:0.110-6.module_1681+b405d8e2.noarch
+    - perl-Data-Section-0:0.200007-3.module_1681+b405d8e2.noarch
+    - perl-Devel-PPPort-0:3.36-5.module_1681+b405d8e2.x86_64
+    - perl-Devel-Peek-0:1.26-410.module_1681+b405d8e2.x86_64
+    - perl-Devel-SelfStubber-0:1.06-410.module_1681+b405d8e2.noarch
+    - perl-Devel-Size-0:0.81-2.module_1681+b405d8e2.x86_64
+    - perl-Digest-0:1.17-395.module_1681+b405d8e2.noarch
+    - perl-Digest-MD5-0:2.55-396.module_1681+b405d8e2.x86_64
+    - perl-Digest-SHA-1:6.01-2.module_1681+b405d8e2.x86_64
+    - perl-Encode-4:2.97-3.module_1681+b405d8e2.x86_64
+    - perl-Encode-devel-4:2.97-3.module_1681+b405d8e2.x86_64
+    - perl-Env-0:1.04-395.module_1681+b405d8e2.noarch
+    - perl-Errno-0:1.28-410.module_1681+b405d8e2.x86_64
+    - perl-Exporter-0:5.72-396.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-CBuilder-1:0.280230-2.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-Command-1:7.34-1.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-Embed-0:1.34-410.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-Install-0:2.14-4.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-MM-Utils-1:7.34-1.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-MakeMaker-1:7.34-1.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-Manifest-0:1.70-395.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-Miniperl-0:1.06-410.module_1681+b405d8e2.noarch
+    - perl-ExtUtils-ParseXS-1:3.35-2.module_1681+b405d8e2.noarch
+    - perl-Fedora-VSP-0:0.001-9.module_1681+b405d8e2.noarch
+    - perl-File-Fetch-0:0.56-2.module_1681+b405d8e2.noarch
+    - perl-File-HomeDir-0:1.002-4.module_1681+b405d8e2.noarch
+    - perl-File-Path-0:2.15-2.module_1681+b405d8e2.noarch
+    - perl-File-Temp-0:0.230.400-396.module_1681+b405d8e2.noarch
+    - perl-File-Which-0:1.22-2.module_1681+b405d8e2.noarch
+    - perl-Filter-2:1.58-2.module_1681+b405d8e2.x86_64
+    - perl-Filter-Simple-0:0.94-2.module_1681+b405d8e2.noarch
+    - perl-Getopt-Long-1:2.50-4.module_1681+b405d8e2.noarch
+    - perl-HTTP-Tiny-0:0.070-395.module_1681+b405d8e2.noarch
+    - perl-IO-0:1.38-410.module_1681+b405d8e2.x86_64
+    - perl-IO-Compress-0:2.081-1.module_1681+b405d8e2.noarch
+    - perl-IO-Socket-IP-0:0.39-5.module_1681+b405d8e2.noarch
+    - perl-IO-Zlib-1:1.10-410.module_1681+b405d8e2.noarch
+    - perl-IPC-Cmd-2:1.00-1.module_1681+b405d8e2.noarch
+    - perl-IPC-SysV-0:2.07-397.module_1681+b405d8e2.x86_64
+    - perl-IPC-System-Simple-0:1.25-17.module_1681+b405d8e2.noarch
+    - perl-JSON-PP-1:2.97.001-2.module_1681+b405d8e2.noarch
+    - perl-Locale-Codes-0:3.56-1.module_1681+b405d8e2.noarch
+    - perl-Locale-Maketext-0:1.28-396.module_1681+b405d8e2.noarch
+    - perl-Locale-Maketext-Simple-1:0.21-410.module_1681+b405d8e2.noarch
+    - perl-MIME-Base64-0:3.15-396.module_1681+b405d8e2.x86_64
+    - perl-MRO-Compat-0:0.13-4.module_1681+b405d8e2.noarch
+    - perl-Math-BigInt-1:1.9998.11-5.module_1681+b405d8e2.noarch
+    - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1681+b405d8e2.x86_64
+    - perl-Math-BigRat-0:0.2613-3.module_1681+b405d8e2.noarch
+    - perl-Math-Complex-0:1.59-410.module_1681+b405d8e2.noarch
+    - perl-Memoize-0:1.03-410.module_1681+b405d8e2.noarch
+    - perl-Module-Build-2:0.42.24-5.module_1681+b405d8e2.noarch
+    - perl-Module-CoreList-1:5.20180414-1.module_1681+b405d8e2.noarch
+    - perl-Module-CoreList-tools-1:5.20180414-1.module_1681+b405d8e2.noarch
+    - perl-Module-Load-1:0.32-395.module_1681+b405d8e2.noarch
+    - perl-Module-Load-Conditional-0:0.68-395.module_1681+b405d8e2.noarch
+    - perl-Module-Loaded-1:0.08-410.module_1681+b405d8e2.noarch
+    - perl-Module-Metadata-0:1.000033-395.module_1681+b405d8e2.noarch
+    - perl-Net-Ping-0:2.55-410.module_1681+b405d8e2.noarch
+    - perl-Package-Generator-0:1.106-11.module_1681+b405d8e2.noarch
+    - perl-Params-Check-1:0.38-395.module_1681+b405d8e2.noarch
+    - perl-Params-Util-0:1.07-22.module_1681+b405d8e2.x86_64
+    - perl-PathTools-0:3.74-1.module_1681+b405d8e2.x86_64
+    - perl-Perl-OSType-0:1.010-396.module_1681+b405d8e2.noarch
+    - perl-PerlIO-via-QuotedPrint-0:0.08-395.module_1681+b405d8e2.noarch
+    - perl-Pod-Checker-4:1.73-395.module_1681+b405d8e2.noarch
+    - perl-Pod-Escapes-1:1.07-395.module_1681+b405d8e2.noarch
+    - perl-Pod-Html-0:1.22.02-410.module_1681+b405d8e2.noarch
+    - perl-Pod-Parser-0:1.63-396.module_1681+b405d8e2.noarch
+    - perl-Pod-Perldoc-0:3.28-396.module_1681+b405d8e2.noarch
+    - perl-Pod-Simple-1:3.35-395.module_1681+b405d8e2.noarch
+    - perl-Pod-Usage-4:1.69-395.module_1681+b405d8e2.noarch
+    - perl-Scalar-List-Utils-3:1.49-2.module_1681+b405d8e2.x86_64
+    - perl-SelfLoader-0:1.23-410.module_1681+b405d8e2.noarch
+    - perl-Socket-4:2.027-2.module_1681+b405d8e2.x86_64
+    - perl-Software-License-0:0.103013-2.module_1681+b405d8e2.noarch
+    - perl-Storable-1:2.62-396.module_1681+b405d8e2.x86_64
+    - perl-Sub-Exporter-0:0.987-15.module_1681+b405d8e2.noarch
+    - perl-Sub-Install-0:0.928-14.module_1681+b405d8e2.noarch
+    - perl-Sys-Syslog-0:0.35-397.module_1681+b405d8e2.x86_64
+    - perl-Term-ANSIColor-0:4.06-396.module_1681+b405d8e2.noarch
+    - perl-Term-Cap-0:1.17-395.module_1681+b405d8e2.noarch
+    - perl-Test-0:1.30-410.module_1681+b405d8e2.noarch
+    - perl-Test-Harness-1:3.42-1.module_1681+b405d8e2.noarch
+    - perl-Test-Simple-1:1.302135-1.module_1681+b405d8e2.noarch
+    - perl-Text-Balanced-0:2.03-395.module_1681+b405d8e2.noarch
+    - perl-Text-Diff-0:1.45-2.module_1681+b405d8e2.noarch
+    - perl-Text-Glob-0:0.11-4.module_1681+b405d8e2.noarch
+    - perl-Text-ParseWords-0:3.30-395.module_1681+b405d8e2.noarch
+    - perl-Text-Tabs+Wrap-0:2013.0523-395.module_1681+b405d8e2.noarch
+    - perl-Text-Template-0:1.51-1.module_1681+b405d8e2.noarch
+    - perl-Thread-Queue-0:3.12-395.module_1681+b405d8e2.noarch
+    - perl-Time-HiRes-0:1.9758-1.module_1681+b405d8e2.x86_64
+    - perl-Time-Local-1:1.250-395.module_1681+b405d8e2.noarch
+    - perl-Time-Piece-0:1.31-410.module_1681+b405d8e2.x86_64
+    - perl-URI-0:1.73-2.module_1681+b405d8e2.noarch
+    - perl-Unicode-Collate-0:1.25-2.module_1681+b405d8e2.x86_64
+    - perl-Unicode-Normalize-0:1.25-396.module_1681+b405d8e2.x86_64
+    - perl-autodie-0:2.29-396.module_1681+b405d8e2.noarch
+    - perl-bignum-0:0.49-2.module_1681+b405d8e2.noarch
+    - perl-constant-0:1.33-396.module_1681+b405d8e2.noarch
+    - perl-devel-4:5.26.2-410.module_1681+b405d8e2.x86_64
+    - perl-encoding-4:2.22-3.module_1681+b405d8e2.x86_64
+    - perl-experimental-0:0.019-2.module_1681+b405d8e2.noarch
+    - perl-generators-0:1.10-7.module_1681+b405d8e2.noarch
+    - perl-homedir-0:2.000024-2.module_1681+b405d8e2.noarch
+    - perl-inc-latest-2:0.500-9.module_1681+b405d8e2.noarch
+    - perl-interpreter-4:5.26.2-410.module_1681+b405d8e2.x86_64
+    - perl-libnet-0:3.11-3.module_1681+b405d8e2.noarch
+    - perl-libnetcfg-4:5.26.2-410.module_1681+b405d8e2.noarch
+    - perl-libs-4:5.26.2-410.module_1681+b405d8e2.x86_64
+    - perl-local-lib-0:2.000024-2.module_1681+b405d8e2.noarch
+    - perl-macros-4:5.26.2-410.module_1681+b405d8e2.x86_64
+    - perl-open-0:1.11-410.module_1681+b405d8e2.noarch
+    - perl-parent-1:0.236-395.module_1681+b405d8e2.noarch
+    - perl-perlfaq-0:5.021011-395.module_1681+b405d8e2.noarch
+    - perl-podlators-0:4.10-2.module_1681+b405d8e2.noarch
+    - perl-tests-4:5.26.2-410.module_1681+b405d8e2.x86_64
+    - perl-threads-1:2.21-2.module_1681+b405d8e2.x86_64
+    - perl-threads-shared-0:1.58-2.module_1681+b405d8e2.x86_64
+    - perl-utils-0:5.26.2-410.module_1681+b405d8e2.noarch
+    - perl-version-6:0.99.23-1.module_1681+b405d8e2.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: perl
+  stream: 5.24
+  version: 20180418132302
+  context: 5d9ae238
+  arch: x86_64
+  summary: Practical Extraction and Report Language
+  description: >
+    Perl is a high-level programming language with roots in C, sed, awk and shell
+    scripting. Perl is good at handling processes and files, and is especially good
+    at handling text. Perl's hallmarks are practicality and efficiency. While it is
+    used to do a lot of different things, Perl's most common applications are system
+    administration utilities and web programming.
+  license:
+    module:
+    - MIT
+    content:
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic)
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic) and BSD and Public Domain and UCD
+    - (GPL+ or Artistic) and (GPLv2+ or Artistic) and MIT
+    - (GPL+ or Artistic) and Artistic 2.0 and UCD
+    - (GPL+ or Artistic) and BSD
+    - (GPL+ or Artistic) and CC0 and Public Domain
+    - (GPL+ or Artistic) and HSLR and MIT and UCD
+    - (GPL+ or Artistic) and MIT
+    - (GPL+ or Artistic) and Public Domain
+    - (GPL+ or Artistic) and UCD
+    - (GPL+ or Artistic) and Unicode
+    - (GPL+ or Artistic) and zlib
+    - ASL 2.0
+    - GPL+
+    - GPL+ or Artistic
+    - GPLv2+ or Artistic
+    - GPLv3+
+    - MIT
+    - TTWL
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/perl.git?#99bb79ac98274ef3fe3f2784057d624e50c0cfcc
+      commit: 99bb79ac98274ef3fe3f2784057d624e50c0cfcc
+      buildrequires:
+        perl-bootstrap:
+          ref: 47f4825a1d5e2a8fd7b76583744ea8f2202c850c
+          stream: 5.24
+          context: 6c81f848
+          version: 20180417065503
+          filtered_rpms: []
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        perl-Text-Diff:
+          ref: 2ee347e962b8a0e83eeecf3324062308cc1d1a2c
+        perl-Text-Balanced:
+          ref: c6648ff72f7b1798642f719036a677102c7ee125
+        perl-File-Fetch:
+          ref: b4bf1bd8af7755b16b40a3dd67cb743bef9b1652
+        perl:
+          ref: 9acafa0017b87ed96f8857fd7099787f0d24ff56
+        perl-Math-BigRat:
+          ref: f45e094a3064ff01662d5e1409e87d88112a1991
+        perl-Math-BigInt-FastCalc:
+          ref: 785456ac9585a8b4f7628d3bd2a0dacd5b592d09
+        perl-Locale-Maketext:
+          ref: 57b31cf2d161ce97448d225af3f86c210d78ad6a
+        perl-Algorithm-Diff:
+          ref: f4b6c06396d4768c691a23b3b967fe6fac1e46ee
+        perl-PathTools:
+          ref: e643e0b6864983a2606f5bcf3ae9a34caeda4059
+        perl-IPC-System-Simple:
+          ref: b899b97739ac1cebcae25357764cd3cf703e4f57
+        perl-CPAN-Meta-Requirements:
+          ref: f693254160585068bd1db62ffa980963a2ef7011
+        perl-Compress-Bzip2:
+          ref: 1ac091378670bfc36b3e866924ddc076cd800cf2
+        perl-IO-Compress:
+          ref: 1e67f30fcc790e2d133ecd756e1b68dc1e423999
+        perl-threads-shared:
+          ref: cd6fd55c5d0ce4aaf7394f4ee865d68c61e91cd1
+        perl-autodie:
+          ref: 40735fb3b9a6b96b40934e72672bb1a04eb0999a
+        perl-constant:
+          ref: f005b65dee6a48411e2dfeb5e057dfb8a3818135
+        perl-bignum:
+          ref: 74c0852bf10b97499c694d3d32f5e66a7a7d7cf3
+        perl-Params-Check:
+          ref: cf2ab4714451509691e4c06f968b0cc71891a8b8
+        perl-Archive-Zip:
+          ref: 948b8e44e8dc5def0baa82a96c46da5bff385086
+        perl-Math-BigInt:
+          ref: 82d8ddba8d0d808a04d9d4cb579df53f65112027
+        perl-podlators:
+          ref: 380d587d637c4b5fe4c1b961aa16cb698ed2a07b
+        perl-ExtUtils-Manifest:
+          ref: 2fd5140cb9441b0445de12b720c5459ed38e95b7
+        perl-Compress-Raw-Zlib:
+          ref: ed5582bb24c481aaa0de7a33ecbf85989e0ddd8c
+        perl-local-lib:
+          ref: 96f72250500b509a87fe9263b81f888812ba08cf
+        perl-libnet:
+          ref: e6cc3a47e0776ada93c3801f06af81fb7b642d38
+        perl-B-Debug:
+          ref: ec558193299b89d6babcf009bdcc18dc7fc48a4e
+        perl-Config-Perl-V:
+          ref: 5a2c9f1ea41e4f07e76062c9598619fed2b4dcb6
+        perl-threads:
+          ref: f0b3ca4a1602b11c483d97aea130e2dea8b8f96f
+        perl-Term-Cap:
+          ref: 28e345f7f785aa5b60572bfa5ba2627ef8dd3033
+        perl-Unicode-Normalize:
+          ref: 6875f415710668a788423fdd80ae712e0c3d3ab2
+        perl-Storable:
+          ref: d76f7a7ba835789a1ca93e3c0db2fc17a9f11907
+        perl-IPC-SysV:
+          ref: 6102b15b4a3e30698673109ddda94a2325123e38
+        perl-IPC-Cmd:
+          ref: fc6bc3efe40775d3e63d811a65ed0cab6aa138e1
+        perl-Time-HiRes:
+          ref: 17004a2568fc6de651cee58816cec8640a825d4c
+        perl-Digest-MD5:
+          ref: 884cdd515f0250589dd4cde8c32a9d77fc55871e
+        perl-Getopt-Long:
+          ref: a7414b0c7a488b9af202fff1eb6a2fb2a3ca6327
+        perl-Module-Metadata:
+          ref: f583f7db4daab0a72bae86e49b549c15f5e2c905
+        perl-version:
+          ref: 098155010f833f432a85cb97754e1080750ec873
+        perl-Devel-Size:
+          ref: 982a54ab4a98fba5339f850fa9cc30af93703d2f
+        perl-Unicode-Collate:
+          ref: c6bc5268528635406bf3237258e7c2969a2bdfc6
+        perl-Env:
+          ref: 58ac31466f9c9824d25b13ad559622dcdd65e20a
+        perl-ExtUtils-MakeMaker:
+          ref: 5d9438be138d0919320b5a6e2324df05fe123d6a
+        perl-File-HomeDir:
+          ref: 2982c5d9f538d8c640c3ca8fee7566d68e5ea68e
+        perl-experimental:
+          ref: cad2845a55a98ca9565be2707c3ff48e984fd1da
+        perl-Data-Dumper:
+          ref: c8ea0bbaafa024bc09c7f29342f584885571eb07
+        perl-ExtUtils-ParseXS:
+          ref: 9398847c09b96f2765b1a03b4b84188e28711273
+        perl-Text-Tabs+Wrap:
+          ref: 90b3a77c499b10b5d34569f8b1b26327495049ea
+        perl-Pod-Perldoc:
+          ref: 842e567a333ccfd2b15be93f230d29414be0f581
+        perl-Devel-PPPort:
+          ref: bd144f784620e5cb43ef9aea61c11d1bb7fe0503
+        perl-CPAN-Meta-YAML:
+          ref: 3609aa7e2ae8ca137d9ff46de25d4b869fdb8c2b
+        perl-Pod-Usage:
+          ref: 9d38a4ee92dafbfdd5e8adf44810304de6bbc9e0
+        perl-Fedora-VSP:
+          ref: 63312d7720e816853bd595cbcdc9d9e3cce0880b
+        perl-CPAN-Meta:
+          ref: 68ca8b0eed6d50eaef11c381b6d8e4754f6c2a7d
+        perl-File-Path:
+          ref: 5848e296d61a3de73f17016f7f37a6395ae0f402
+        perl-generators:
+          ref: 87c9a690dd58beeaa573074d26fccccb089ab31b
+        perl-Digest:
+          ref: 6867766aaf85865d33675be774af4751b8ae9549
+        perl-Perl-OSType:
+          ref: c2efc33ea89adb7c2da626cc3d436bbc69203e2b
+        perl-Pod-Simple:
+          ref: a0eec0341f8cc19d74f6f21f9bf38781446a0ad1
+        perl-Sub-Install:
+          ref: 799f7222e97cc90f9abb7e1f02a5847d71a83cb0
+        perl-PerlIO-via-QuotedPrint:
+          ref: 31eb1e0e1c723aaf09d6846b9016e4db94428700
+        perl-HTTP-Tiny:
+          ref: d396ccfe1aadc5746420b06e268e04316eb62c44
+        perl-Text-Template:
+          ref: 9309a484a2e8e309272c8916cf63a12e385eaaef
+        perl-Pod-Parser:
+          ref: efe0977afc65bae502a4ee5bc47430b4e2b6702f
+        perl-Pod-Escapes:
+          ref: 1ab928503d1824c54a6a32e6b5d527b389f34d05
+        perl-Package-Generator:
+          ref: f78e39fa9dc3fd1474475eabcb9378375142dd70
+        perl-Sys-Syslog:
+          ref: 008e476eb1f3e015ad34f302a4cad874e4aad33a
+        perl-Archive-Tar:
+          ref: 2bd7368d3debb90e1d87c3d44db91412fd39873c
+        perl-Time-Local:
+          ref: e74a3e804e77a0d704eebdede825b6d0d6cc617b
+        perl-perlfaq:
+          ref: 63e299c953b8f4b558fe904fc7d31763f79760f1
+        perl-JSON-PP:
+          ref: 1e3fe253e7edbdc506418a38d666ed19db8ce136
+        perl-Term-ANSIColor:
+          ref: 3a74f9162f818ffaa4069d74c931caef0560514b
+        perl-MRO-Compat:
+          ref: 13cfd3efff5d02609bf8fe0c36a9e7a9a37ca8b8
+        perl-Locale-Codes:
+          ref: bd6e31d21f18e85ffe4411b0ce7238d6a974063a
+        perl-Test-Harness:
+          ref: 2ddba30c66331628ef273a6df6b67e2b05d76022
+        perl-Sub-Exporter:
+          ref: 92259c19826f0aed436f04d886cf4e1f208ff103
+        perl-Socket:
+          ref: 14bd5dedb6ff8da7d7b0f5945aa61ffa620777d1
+        perl-Module-CoreList:
+          ref: 6b31db0c22a4824a2ae7c40114a8af17bcfd125b
+        perl-Carp:
+          ref: 84fbaf6f236f9a082ae6960bbbd160f6e75894c5
+        perl-Filter-Simple:
+          ref: ca5e4217e059a7371a125419071852760d031dba
+        perl-Pod-Checker:
+          ref: 6c8f684a9863678be5724c2e565ba1aa62761151
+        perl-Compress-Raw-Bzip2:
+          ref: b989d850d818cbaeba0c47b0d975e1afd6b34bb8
+        perl-DB_File:
+          ref: d9d4b751bd8ea51672630f3beb1ecaf899de40ad
+        perl-Filter:
+          ref: 998996cc8b57f55172167da01155d3a7b59c1e99
+        perl-inc-latest:
+          ref: 0a60ae8876d88d2eaac83b84d6d2fff8ced1b9a1
+        perl-Params-Util:
+          ref: 4bfebd9e4cb2fe6a52e2ae69d5e5e74b36296f9f
+        perl-Module-Load-Conditional:
+          ref: bb49232617058d8af4f199db9972f04cd3eefe0d
+        perl-ExtUtils-CBuilder:
+          ref: 521e6f6f83dc9a5afbb517d85e637bfa69f59701
+        perl-Data-Section:
+          ref: 6ed48ef1733de62cd245237e25d93ea9a827d5e6
+        perl-Scalar-List-Utils:
+          ref: 7eb2ea6397b7fbeeaeacbb176bbbc453723ded1a
+        perl-Text-ParseWords:
+          ref: 1c120cf2934e246a59a5f37284ac8111c52fa806
+        perl-Encode:
+          ref: 346cfe7ccbce4c3cc2a4739b628d8d0b7e1a4779
+        perl-Module-Build:
+          ref: 2c9e4f8f3788caeaa4707f7b562f1ad39a416680
+        perl-Thread-Queue:
+          ref: e0fff689fc097ecf54bac2f09e5e7bd3c4d00ef6
+        perl-Exporter:
+          ref: 14c101bc77bc5119c4f75065d6f4b6edea4b502a
+        perl-Software-License:
+          ref: da9a11a3ad14d5a4cbfe9b52d108b672a6939d69
+        perl-Digest-SHA:
+          ref: 2b4a62eaf739a7d2ce6649f3a326dbd562ed8b74
+        perl-File-Temp:
+          ref: de8e0c3e7e630e6861a0c0979c5ab60227f7de8e
+        perl-URI:
+          ref: 28d53fda027d3a984ffa201d4494389c6b7796b0
+        perl-Data-OptList:
+          ref: 9512df0280d65abfaa04d6437367705c3b19b54f
+        perl-ExtUtils-Install:
+          ref: 507084f8349f691d4688fe9a49e92be1711874e4
+        perl-MIME-Base64:
+          ref: da62d3707ea9781efc91ba48d47ce49b2297a364
+        perl-Test-Simple:
+          ref: e64b2e39f56e17d7b9046881d589c778aaf4ce8b
+        perl-File-Which:
+          ref: 1a2ca4a9b713f31c6f99f6dec3dafdd0a457a44f
+        perl-CPAN:
+          ref: 4159d449e5a66ddef70d1fe7f1d37279d4d99bc5
+        perl-Text-Glob:
+          ref: 346be0660f0fc621a960467b5fa1ee656b9cd87f
+        perl-Module-Load:
+          ref: 3f98c8f286677f7b700f661545154e781798ef0c
+        perl-IO-Socket-IP:
+          ref: 4e56568b5d09ad4aefccb354183614ae5b3f6235
+        perl-parent:
+          ref: f50da57010454e2279d899a57fdbc65a48edc74c
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/modularity-modules/perl
+    tracker: https://github.com/modularity-modules/perl/issues
+  profiles:
+    default:
+      rpms:
+      - perl-core
+    minimal:
+      rpms:
+      - perl
+  api:
+    rpms:
+    - perl
+    - perl-Algorithm-Diff
+    - perl-Archive-Tar
+    - perl-Archive-Zip
+    - perl-Attribute-Handlers
+    - perl-B-Debug
+    - perl-CPAN
+    - perl-CPAN-Meta
+    - perl-CPAN-Meta-Requirements
+    - perl-CPAN-Meta-YAML
+    - perl-Carp
+    - perl-Compress-Bzip2
+    - perl-Compress-Raw-Bzip2
+    - perl-Compress-Raw-Zlib
+    - perl-Config-Perl-V
+    - perl-DB_File
+    - perl-Data-Dumper
+    - perl-Data-OptList
+    - perl-Data-Section
+    - perl-Devel-PPPort
+    - perl-Devel-Peek
+    - perl-Devel-SelfStubber
+    - perl-Devel-Size
+    - perl-Digest
+    - perl-Digest-MD5
+    - perl-Digest-SHA
+    - perl-Encode
+    - perl-Encode-devel
+    - perl-Env
+    - perl-Errno
+    - perl-Exporter
+    - perl-ExtUtils-CBuilder
+    - perl-ExtUtils-Command
+    - perl-ExtUtils-Embed
+    - perl-ExtUtils-Install
+    - perl-ExtUtils-MM-Utils
+    - perl-ExtUtils-MakeMaker
+    - perl-ExtUtils-Manifest
+    - perl-ExtUtils-Miniperl
+    - perl-ExtUtils-ParseXS
+    - perl-Fedora-VSP
+    - perl-File-Fetch
+    - perl-File-HomeDir
+    - perl-File-Path
+    - perl-File-Temp
+    - perl-File-Which
+    - perl-Filter
+    - perl-Filter-Simple
+    - perl-Getopt-Long
+    - perl-HTTP-Tiny
+    - perl-IO
+    - perl-IO-Compress
+    - perl-IO-Socket-IP
+    - perl-IO-Zlib
+    - perl-IPC-Cmd
+    - perl-IPC-SysV
+    - perl-IPC-System-Simple
+    - perl-JSON-PP
+    - perl-Locale-Codes
+    - perl-Locale-Maketext
+    - perl-Locale-Maketext-Simple
+    - perl-MIME-Base64
+    - perl-MRO-Compat
+    - perl-Math-BigInt
+    - perl-Math-BigInt-FastCalc
+    - perl-Math-BigRat
+    - perl-Math-Complex
+    - perl-Memoize
+    - perl-Module-Build
+    - perl-Module-CoreList
+    - perl-Module-CoreList-tools
+    - perl-Module-Load
+    - perl-Module-Load-Conditional
+    - perl-Module-Loaded
+    - perl-Module-Metadata
+    - perl-Net-Ping
+    - perl-Package-Generator
+    - perl-Params-Check
+    - perl-Params-Util
+    - perl-PathTools
+    - perl-Perl-OSType
+    - perl-PerlIO-via-QuotedPrint
+    - perl-Pod-Checker
+    - perl-Pod-Escapes
+    - perl-Pod-Html
+    - perl-Pod-Parser
+    - perl-Pod-Perldoc
+    - perl-Pod-Simple
+    - perl-Pod-Usage
+    - perl-Scalar-List-Utils
+    - perl-SelfLoader
+    - perl-Socket
+    - perl-Software-License
+    - perl-Storable
+    - perl-Sub-Exporter
+    - perl-Sub-Install
+    - perl-Sys-Syslog
+    - perl-Term-ANSIColor
+    - perl-Term-Cap
+    - perl-Test
+    - perl-Test-Harness
+    - perl-Test-Simple
+    - perl-Text-Balanced
+    - perl-Text-Diff
+    - perl-Text-Glob
+    - perl-Text-ParseWords
+    - perl-Text-Tabs+Wrap
+    - perl-Text-Template
+    - perl-Thread-Queue
+    - perl-Time-HiRes
+    - perl-Time-Local
+    - perl-Time-Piece
+    - perl-URI
+    - perl-Unicode-Collate
+    - perl-Unicode-Normalize
+    - perl-autodie
+    - perl-bignum
+    - perl-constant
+    - perl-devel
+    - perl-encoding
+    - perl-experimental
+    - perl-generators
+    - perl-homedir
+    - perl-inc-latest
+    - perl-interpreter
+    - perl-libnet
+    - perl-libnetcfg
+    - perl-libs
+    - perl-local-lib
+    - perl-macros
+    - perl-open
+    - perl-parent
+    - perl-perlfaq
+    - perl-podlators
+    - perl-tests
+    - perl-threads
+    - perl-threads-shared
+    - perl-utils
+    - perl-version
+  buildopts:
+    rpms:
+      macros: |
+        %_with_perl_enables_groff 1
+        %_without_perl_enables_syslog_test 1
+        %_with_perl_enables_systemtap 1
+        %_without_perl_enables_tcsh 1
+        %_without_perl_Compress_Bzip2_enables_optional_test 1
+        %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+        %_without_perl_IPC_System_Simple_enables_optional_test 1
+        %_without_perl_LWP_MediaTypes_enables_mailcap 1
+        %_without_perl_Module_Build_enables_optional_test 1
+        %_without_perl_Perl_OSType_enables_optional_test 1
+        %_without_perl_Pod_Perldoc_enables_tk_test 1
+        %_without_perl_Software_License_enables_optional_test 1
+        %_without_perl_Sys_Syslog_enables_optional_test 1
+        %_without_perl_Test_Harness_enables_optional_test 1
+        %_without_perl_URI_enables_Business_ISBN 1
+  components:
+    rpms:
+      perl:
+        rationale: The Perl interpreter.
+        repository: git://pkgs.fedoraproject.org/rpms/perl
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl
+        ref: f26
+      perl-Algorithm-Diff:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Algorithm-Diff
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Algorithm-Diff
+        ref: f26
+      perl-Archive-Tar:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Archive-Tar
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Archive-Tar
+        ref: f26
+      perl-Archive-Zip:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Archive-Zip
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Archive-Zip
+        ref: f26
+      perl-B-Debug:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-B-Debug
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-B-Debug
+        ref: f26
+      perl-CPAN:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN
+        ref: f26
+      perl-CPAN-Meta:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta
+        ref: f26
+      perl-CPAN-Meta-Requirements:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-Requirements
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-Requirements
+        ref: f26
+      perl-CPAN-Meta-YAML:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-CPAN-Meta-YAML
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-CPAN-Meta-YAML
+        ref: f26
+      perl-Carp:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Carp
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Carp
+        ref: f26
+      perl-Compress-Bzip2:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Bzip2
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Bzip2
+        ref: f26
+      perl-Compress-Raw-Bzip2:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Raw-Bzip2
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Raw-Bzip2
+        ref: f26
+      perl-Compress-Raw-Zlib:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Compress-Raw-Zlib
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Compress-Raw-Zlib
+        ref: f26
+      perl-Config-Perl-V:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Config-Perl-V
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Config-Perl-V
+        ref: f26
+      perl-DB_File:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-DB_File
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-DB_File
+        ref: f26
+      perl-Data-Dumper:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-Dumper
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-Dumper
+        ref: f26
+      perl-Data-OptList:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-OptList
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-OptList
+        ref: f26
+      perl-Data-Section:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Data-Section
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Data-Section
+        ref: f26
+      perl-Devel-PPPort:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-PPPort
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-PPPort
+        ref: f26
+      perl-Devel-Size:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Devel-Size
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Devel-Size
+        ref: f26
+      perl-Digest:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest
+        ref: f26
+      perl-Digest-MD5:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-MD5
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-MD5
+        ref: f26
+      perl-Digest-SHA:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Digest-SHA
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Digest-SHA
+        ref: f26
+      perl-Encode:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Encode
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Encode
+        ref: f26
+      perl-Env:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Env
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Env
+        ref: f26
+      perl-Exporter:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Exporter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Exporter
+        ref: f26
+      perl-ExtUtils-CBuilder:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-CBuilder
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-CBuilder
+        ref: f26
+      perl-ExtUtils-Install:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-Install
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-Install
+        ref: f26
+      perl-ExtUtils-MakeMaker:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-MakeMaker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-MakeMaker
+        ref: f26
+      perl-ExtUtils-Manifest:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-Manifest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-Manifest
+        ref: f26
+      perl-ExtUtils-ParseXS:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-ExtUtils-ParseXS
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-ExtUtils-ParseXS
+        ref: f26
+      perl-Fedora-VSP:
+        rationale: RPM dependency generator.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Fedora-VSP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Fedora-VSP
+        ref: f26
+      perl-File-Fetch:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Fetch
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Fetch
+        ref: f26
+      perl-File-HomeDir:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-HomeDir
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-HomeDir
+        ref: f26
+      perl-File-Path:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Path
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Path
+        ref: f26
+      perl-File-Temp:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Temp
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Temp
+        ref: f26
+      perl-File-Which:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-File-Which
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-File-Which
+        ref: f26
+      perl-Filter:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Filter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Filter
+        ref: f26
+      perl-Filter-Simple:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Filter-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Filter-Simple
+        ref: f26
+      perl-Getopt-Long:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Getopt-Long
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Getopt-Long
+        ref: f26
+      perl-HTTP-Tiny:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-HTTP-Tiny
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-HTTP-Tiny
+        ref: f26
+      perl-IO-Compress:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Compress
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Compress
+        ref: f26
+      perl-IO-Socket-IP:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IO-Socket-IP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IO-Socket-IP
+        ref: f26
+      perl-IPC-Cmd:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-Cmd
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-Cmd
+        ref: f26
+      perl-IPC-SysV:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-SysV
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-SysV
+        ref: f26
+      perl-IPC-System-Simple:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-IPC-System-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-IPC-System-Simple
+        ref: f26
+      perl-JSON-PP:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-JSON-PP
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-JSON-PP
+        ref: f26
+      perl-Locale-Codes:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Locale-Codes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Locale-Codes
+        ref: f26
+      perl-Locale-Maketext:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Locale-Maketext
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Locale-Maketext
+        ref: f26
+      perl-MIME-Base64:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-MIME-Base64
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-MIME-Base64
+        ref: f26
+      perl-MRO-Compat:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-MRO-Compat
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-MRO-Compat
+        ref: f26
+      perl-Math-BigInt:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigInt
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigInt
+        ref: f26
+      perl-Math-BigInt-FastCalc:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigInt-FastCalc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigInt-FastCalc
+        ref: f26
+      perl-Math-BigRat:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Math-BigRat
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Math-BigRat
+        ref: f26
+      perl-Module-Build:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Build
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Build
+        ref: f26
+      perl-Module-CoreList:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-CoreList
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-CoreList
+        ref: f26
+      perl-Module-Load:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Load
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Load
+        ref: f26
+      perl-Module-Load-Conditional:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Load-Conditional
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Load-Conditional
+        ref: f26
+      perl-Module-Metadata:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Module-Metadata
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Module-Metadata
+        ref: f26
+      perl-Package-Generator:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Package-Generator
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Package-Generator
+        ref: f26
+      perl-Params-Check:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Params-Check
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Params-Check
+        ref: f26
+      perl-Params-Util:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Params-Util
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Params-Util
+        ref: f26
+      perl-PathTools:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PathTools
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PathTools
+        ref: f26
+      perl-Perl-OSType:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Perl-OSType
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Perl-OSType
+        ref: f26
+      perl-PerlIO-via-QuotedPrint:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-PerlIO-via-QuotedPrint
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-PerlIO-via-QuotedPrint
+        ref: f26
+      perl-Pod-Checker:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Checker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Checker
+        ref: f26
+      perl-Pod-Escapes:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Escapes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Escapes
+        ref: f26
+      perl-Pod-Parser:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Parser
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Parser
+        ref: f26
+      perl-Pod-Perldoc:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Perldoc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Perldoc
+        ref: f26
+      perl-Pod-Simple:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Simple
+        ref: f26
+      perl-Pod-Usage:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Pod-Usage
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Pod-Usage
+        ref: f26
+      perl-Scalar-List-Utils:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Scalar-List-Utils
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Scalar-List-Utils
+        ref: f26
+      perl-Socket:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Socket
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Socket
+        ref: f26
+      perl-Software-License:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Software-License
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Software-License
+        ref: f26
+      perl-Storable:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Storable
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Storable
+        ref: f26
+      perl-Sub-Exporter:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Exporter
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Exporter
+        ref: f26
+      perl-Sub-Install:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sub-Install
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sub-Install
+        ref: f26
+      perl-Sys-Syslog:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Sys-Syslog
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Sys-Syslog
+        ref: f26
+      perl-Term-ANSIColor:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Term-ANSIColor
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Term-ANSIColor
+        ref: f26
+      perl-Term-Cap:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Term-Cap
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Term-Cap
+        ref: f26
+      perl-Test-Harness:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Harness
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Harness
+        ref: f26
+      perl-Test-Simple:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Test-Simple
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Test-Simple
+        ref: f26
+      perl-Text-Balanced:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Balanced
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Balanced
+        ref: f26
+      perl-Text-Diff:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Diff
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Diff
+        ref: f26
+      perl-Text-Glob:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Glob
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Glob
+        ref: f26
+      perl-Text-ParseWords:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-ParseWords
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-ParseWords
+        ref: f26
+      perl-Text-Tabs+Wrap:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Tabs+Wrap
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Tabs+Wrap
+        ref: f26
+      perl-Text-Template:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Text-Template
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Text-Template
+        ref: f26
+      perl-Thread-Queue:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Thread-Queue
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Thread-Queue
+        ref: f26
+      perl-Time-HiRes:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Time-HiRes
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Time-HiRes
+        ref: f26
+      perl-Time-Local:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Time-Local
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Time-Local
+        ref: f26
+      perl-URI:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-URI
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-URI
+        ref: f26
+      perl-Unicode-Collate:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Unicode-Collate
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Unicode-Collate
+        ref: f26
+      perl-Unicode-Normalize:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-Unicode-Normalize
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Unicode-Normalize
+        ref: f26
+      perl-autodie:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-autodie
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-autodie
+        ref: f26
+      perl-bignum:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-bignum
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-bignum
+        ref: f26
+      perl-constant:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-constant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-constant
+        ref: f26
+      perl-experimental:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-experimental
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-experimental
+        ref: f26
+      perl-generators:
+        rationale: RPM dependency generator.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-generators
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-generators
+        ref: f26
+      perl-inc-latest:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-inc-latest
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-inc-latest
+        ref: f26
+      perl-libnet:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-libnet
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-libnet
+        ref: f26
+      perl-local-lib:
+        rationale: A run-time dependency.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-local-lib
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-local-lib
+        ref: f26
+      perl-parent:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-parent
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-parent
+        ref: f26
+      perl-perlfaq:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-perlfaq
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-perlfaq
+        ref: f26
+      perl-podlators:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-podlators
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-podlators
+        ref: f26
+      perl-threads:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-threads
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-threads
+        ref: f26
+      perl-threads-shared:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-threads-shared
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-threads-shared
+        ref: f26
+      perl-version:
+        rationale: Core Perl API.
+        repository: git://pkgs.fedoraproject.org/rpms/perl-version
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-version
+        ref: f26
+  artifacts:
+    rpms:
+    - perl-4:5.24.4-397.module_1688+d7b5e208.x86_64
+    - perl-Algorithm-Diff-0:1.1903-6.module_1688+d7b5e208.noarch
+    - perl-Archive-Tar-0:2.26-1.module_1688+d7b5e208.noarch
+    - perl-Archive-Zip-0:1.59-3.module_1688+d7b5e208.noarch
+    - perl-Attribute-Handlers-0:0.99-397.module_1688+d7b5e208.noarch
+    - perl-B-Debug-0:1.24-2.module_1688+d7b5e208.noarch
+    - perl-CPAN-0:2.16-1.module_1688+d7b5e208.noarch
+    - perl-CPAN-Meta-0:2.150010-2.module_1688+d7b5e208.noarch
+    - perl-CPAN-Meta-Requirements-0:2.140-7.module_1688+d7b5e208.noarch
+    - perl-CPAN-Meta-YAML-0:0.018-367.module_1688+d7b5e208.noarch
+    - perl-Carp-0:1.40-366.module_1688+d7b5e208.noarch
+    - perl-Compress-Bzip2-0:2.26-1.module_1688+d7b5e208.x86_64
+    - perl-Compress-Raw-Bzip2-0:2.074-1.module_1688+d7b5e208.x86_64
+    - perl-Compress-Raw-Zlib-0:2.074-1.module_1688+d7b5e208.x86_64
+    - perl-Config-Perl-V-0:0.27-2.module_1688+d7b5e208.noarch
+    - perl-DB_File-0:1.841-1.module_1688+d7b5e208.x86_64
+    - perl-Data-Dumper-0:2.161-4.module_1688+d7b5e208.x86_64
+    - perl-Data-OptList-0:0.110-3.module_1688+d7b5e208.noarch
+    - perl-Data-Section-0:0.200006-8.module_1688+d7b5e208.noarch
+    - perl-Devel-PPPort-0:3.36-1.module_1688+d7b5e208.x86_64
+    - perl-Devel-Peek-0:1.23-397.module_1688+d7b5e208.x86_64
+    - perl-Devel-SelfStubber-0:1.05-397.module_1688+d7b5e208.noarch
+    - perl-Devel-Size-0:0.81-1.module_1688+d7b5e208.x86_64
+    - perl-Digest-0:1.17-367.module_1688+d7b5e208.noarch
+    - perl-Digest-MD5-0:2.55-3.module_1688+d7b5e208.x86_64
+    - perl-Digest-SHA-1:6.01-1.module_1688+d7b5e208.x86_64
+    - perl-Encode-4:2.88-6.module_1688+d7b5e208.x86_64
+    - perl-Encode-devel-4:2.88-6.module_1688+d7b5e208.x86_64
+    - perl-Env-0:1.04-366.module_1688+d7b5e208.noarch
+    - perl-Errno-0:1.25-397.module_1688+d7b5e208.x86_64
+    - perl-Exporter-0:5.72-367.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-CBuilder-1:0.280225-366.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-Command-0:7.24-3.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-Embed-0:1.33-397.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-Install-0:2.04-367.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-MM-Utils-0:7.24-3.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-MakeMaker-0:7.24-3.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-Manifest-0:1.70-366.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-Miniperl-0:1.05-397.module_1688+d7b5e208.noarch
+    - perl-ExtUtils-ParseXS-1:3.31-368.module_1688+d7b5e208.noarch
+    - perl-Fedora-VSP-0:0.001-5.module_1688+d7b5e208.noarch
+    - perl-File-Fetch-0:0.56-1.module_1688+d7b5e208.noarch
+    - perl-File-HomeDir-0:1.00-13.module_1688+d7b5e208.noarch
+    - perl-File-Path-0:2.12-367.module_1688+d7b5e208.noarch
+    - perl-File-Temp-0:0.230.400-2.module_1688+d7b5e208.noarch
+    - perl-File-Which-0:1.21-3.module_1688+d7b5e208.noarch
+    - perl-Filter-2:1.58-1.module_1688+d7b5e208.x86_64
+    - perl-Filter-Simple-0:0.92-366.module_1688+d7b5e208.noarch
+    - perl-Getopt-Long-0:2.49.1-2.module_1688+d7b5e208.noarch
+    - perl-HTTP-Tiny-0:0.070-2.module_1688+d7b5e208.noarch
+    - perl-IO-0:1.36-397.module_1688+d7b5e208.x86_64
+    - perl-IO-Compress-0:2.074-1.module_1688+d7b5e208.noarch
+    - perl-IO-Socket-IP-0:0.39-1.module_1688+d7b5e208.noarch
+    - perl-IO-Zlib-1:1.10-397.module_1688+d7b5e208.noarch
+    - perl-IPC-Cmd-1:0.98-1.module_1688+d7b5e208.noarch
+    - perl-IPC-SysV-0:2.07-4.module_1688+d7b5e208.x86_64
+    - perl-IPC-System-Simple-0:1.25-13.module_1688+d7b5e208.noarch
+    - perl-JSON-PP-0:2.94000-1.module_1688+d7b5e208.noarch
+    - perl-Locale-Codes-0:3.42-2.module_1688+d7b5e208.noarch
+    - perl-Locale-Maketext-0:1.28-2.module_1688+d7b5e208.noarch
+    - perl-Locale-Maketext-Simple-1:0.21-397.module_1688+d7b5e208.noarch
+    - perl-MIME-Base64-0:3.15-366.module_1688+d7b5e208.x86_64
+    - perl-MRO-Compat-0:0.13-1.module_1688+d7b5e208.noarch
+    - perl-Math-BigInt-0:1.9998.11-1.module_1688+d7b5e208.noarch
+    - perl-Math-BigInt-FastCalc-0:0.500.600-2.module_1688+d7b5e208.x86_64
+    - perl-Math-BigRat-0:0.2614-1.module_1688+d7b5e208.noarch
+    - perl-Math-Complex-0:1.59-397.module_1688+d7b5e208.noarch
+    - perl-Memoize-0:1.03-397.module_1688+d7b5e208.noarch
+    - perl-Module-Build-2:0.42.24-1.module_1688+d7b5e208.noarch
+    - perl-Module-CoreList-1:5.20180414-1.module_1688+d7b5e208.noarch
+    - perl-Module-CoreList-tools-1:5.20180414-1.module_1688+d7b5e208.noarch
+    - perl-Module-Load-1:0.32-366.module_1688+d7b5e208.noarch
+    - perl-Module-Load-Conditional-0:0.68-2.module_1688+d7b5e208.noarch
+    - perl-Module-Loaded-1:0.08-397.module_1688+d7b5e208.noarch
+    - perl-Module-Metadata-0:1.000033-2.module_1688+d7b5e208.noarch
+    - perl-Net-Ping-0:2.43-397.module_1688+d7b5e208.noarch
+    - perl-Package-Generator-0:1.106-8.module_1688+d7b5e208.noarch
+    - perl-Params-Check-1:0.38-366.module_1688+d7b5e208.noarch
+    - perl-Params-Util-0:1.07-17.module_1688+d7b5e208.x86_64
+    - perl-PathTools-0:3.63-367.module_1688+d7b5e208.x86_64
+    - perl-Perl-OSType-0:1.010-4.module_1688+d7b5e208.noarch
+    - perl-PerlIO-via-QuotedPrint-0:0.08-366.module_1688+d7b5e208.noarch
+    - perl-Pod-Checker-4:1.73-2.module_1688+d7b5e208.noarch
+    - perl-Pod-Escapes-1:1.07-366.module_1688+d7b5e208.noarch
+    - perl-Pod-Html-0:1.22.01-397.module_1688+d7b5e208.noarch
+    - perl-Pod-Parser-0:1.63-367.module_1688+d7b5e208.noarch
+    - perl-Pod-Perldoc-0:3.28-2.module_1688+d7b5e208.noarch
+    - perl-Pod-Simple-1:3.35-2.module_1688+d7b5e208.noarch
+    - perl-Pod-Usage-4:1.69-2.module_1688+d7b5e208.noarch
+    - perl-Scalar-List-Utils-3:1.48-1.module_1688+d7b5e208.x86_64
+    - perl-SelfLoader-0:1.23-397.module_1688+d7b5e208.noarch
+    - perl-Socket-4:2.027-1.module_1688+d7b5e208.x86_64
+    - perl-Software-License-0:0.103012-4.module_1688+d7b5e208.noarch
+    - perl-Storable-1:2.56-368.module_1688+d7b5e208.x86_64
+    - perl-Sub-Exporter-0:0.987-11.module_1688+d7b5e208.noarch
+    - perl-Sub-Install-0:0.928-10.module_1688+d7b5e208.noarch
+    - perl-Sys-Syslog-0:0.35-2.module_1688+d7b5e208.x86_64
+    - perl-Term-ANSIColor-0:4.06-2.module_1688+d7b5e208.noarch
+    - perl-Term-Cap-0:1.17-366.module_1688+d7b5e208.noarch
+    - perl-Test-0:1.28-397.module_1688+d7b5e208.noarch
+    - perl-Test-Harness-0:3.42-1.module_1688+d7b5e208.noarch
+    - perl-Test-Simple-1:1.302086-1.module_1688+d7b5e208.noarch
+    - perl-Text-Balanced-0:2.03-366.module_1688+d7b5e208.noarch
+    - perl-Text-Diff-0:1.44-3.module_1688+d7b5e208.noarch
+    - perl-Text-Glob-0:0.11-1.module_1688+d7b5e208.noarch
+    - perl-Text-ParseWords-0:3.30-366.module_1688+d7b5e208.noarch
+    - perl-Text-Tabs+Wrap-0:2013.0523-366.module_1688+d7b5e208.noarch
+    - perl-Text-Template-0:1.47-1.module_1688+d7b5e208.noarch
+    - perl-Thread-Queue-0:3.12-1.module_1688+d7b5e208.noarch
+    - perl-Time-HiRes-0:1.9753-1.module_1688+d7b5e208.x86_64
+    - perl-Time-Local-1:1.250-2.module_1688+d7b5e208.noarch
+    - perl-Time-Piece-0:1.31-397.module_1688+d7b5e208.x86_64
+    - perl-URI-0:1.71-6.module_1688+d7b5e208.noarch
+    - perl-Unicode-Collate-0:1.20-1.module_1688+d7b5e208.x86_64
+    - perl-Unicode-Normalize-0:1.25-366.module_1688+d7b5e208.x86_64
+    - perl-autodie-0:2.29-367.module_1688+d7b5e208.noarch
+    - perl-bignum-0:0.49-1.module_1688+d7b5e208.noarch
+    - perl-constant-0:1.33-368.module_1688+d7b5e208.noarch
+    - perl-core-0:5.24.4-397.module_1688+d7b5e208.x86_64
+    - perl-devel-4:5.24.4-397.module_1688+d7b5e208.x86_64
+    - perl-encoding-4:2.19-6.module_1688+d7b5e208.x86_64
+    - perl-experimental-0:0.019-1.module_1688+d7b5e208.noarch
+    - perl-generators-0:1.10-2.module_1688+d7b5e208.noarch
+    - perl-homedir-0:2.000023-1.module_1688+d7b5e208.noarch
+    - perl-inc-latest-2:0.500-6.module_1688+d7b5e208.noarch
+    - perl-libnet-0:3.11-1.module_1688+d7b5e208.noarch
+    - perl-libnetcfg-4:5.24.4-397.module_1688+d7b5e208.noarch
+    - perl-libs-4:5.24.4-397.module_1688+d7b5e208.x86_64
+    - perl-local-lib-0:2.000023-1.module_1688+d7b5e208.noarch
+    - perl-macros-4:5.24.4-397.module_1688+d7b5e208.x86_64
+    - perl-open-0:1.10-397.module_1688+d7b5e208.noarch
+    - perl-parent-1:0.236-2.module_1688+d7b5e208.noarch
+    - perl-perlfaq-0:5.021011-3.module_1688+d7b5e208.noarch
+    - perl-podlators-0:4.09-3.module_1688+d7b5e208.noarch
+    - perl-tests-4:5.24.4-397.module_1688+d7b5e208.x86_64
+    - perl-threads-1:2.21-1.module_1688+d7b5e208.x86_64
+    - perl-threads-shared-0:1.58-1.module_1688+d7b5e208.x86_64
+    - perl-utils-0:5.24.4-397.module_1688+d7b5e208.noarch
+    - perl-version-5:0.99.18-1.module_1688+d7b5e208.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 8
+  version: 20180816123422
+  context: 6c81f848
+  arch: x86_64
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT and ASL 2.0 and ISC and BSD
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/nodejs.git?#bc228d9478ac1b4387f55b6dc0b6dce38db7a7b9
+      commit: bc228d9478ac1b4387f55b6dc0b6dce38db7a7b9
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        nodejs:
+          ref: 0d185d83353950699b7016d89a66d3916e0168b0
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git://pkgs.fedoraproject.org/rpms/nodejs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/nodejs
+        ref: 8
+        buildorder: 10
+  artifacts:
+    rpms:
+    - nodejs-1:8.11.4-1.module_2030+42747d40.x86_64
+    - nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
+    - nodejs-docs-1:8.11.4-1.module_2030+42747d40.noarch
+    - npm-1:5.6.0-1.8.11.4.1.module_2030+42747d40.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 10
+  version: 20180920144631
+  context: 6c81f848
+  arch: x86_64
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+    - MIT and ASL 2.0 and ISC and BSD
+    - MIT and BSD and ISC
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/nodejs.git?#768aa610027667d9b67d05b9d1aa94de4a20f44b
+      commit: 768aa610027667d9b67d05b9d1aa94de4a20f44b
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        nodejs:
+          ref: 74ef5461c130a9b009f9f194b2b9865b2a459f3c
+        nghttp2:
+          ref: 67592912fdb33b88075882934e4ec1b551f97cd3
+        libuv:
+          ref: b47ae1758ba157e78837eb4ac759a1ea3d5dd734
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      libuv:
+        rationale: Platform abstraction layer for Node.js
+        repository: git+https://src.fedoraproject.org/rpms/libuv
+        cache: https://src.fedoraproject.org/repo/pkgs/libuv
+        ref: 1
+      nghttp2:
+        rationale: Needed for HTTP2 support
+        repository: git+https://src.fedoraproject.org/rpms/nghttp2
+        cache: https://src.fedoraproject.org/repo/pkgs/nghttp2
+        ref: master
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git+https://src.fedoraproject.org/rpms/nodejs
+        cache: https://src.fedoraproject.org/repo/pkgs/nodejs
+        ref: 10
+        buildorder: 10
+  artifacts:
+    rpms:
+    - libnghttp2-0:1.33.0-1.module_2177+2526c218.x86_64
+    - libnghttp2-devel-0:1.33.0-1.module_2177+2526c218.x86_64
+    - libuv-1:1.23.0-1.module_2177+2526c218.x86_64
+    - libuv-devel-1:1.23.0-1.module_2177+2526c218.x86_64
+    - libuv-static-1:1.23.0-1.module_2177+2526c218.x86_64
+    - nghttp2-0:1.33.0-1.module_2177+2526c218.x86_64
+    - nodejs-1:10.11.0-1.module_2200+adbac02b.x86_64
+    - nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
+    - nodejs-docs-1:10.11.0-1.module_2200+adbac02b.noarch
+    - npm-1:6.4.1-1.10.11.0.1.module_2200+adbac02b.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: ninja
+  stream: master
+  version: 20180816141421
+  context: 6c81f848
+  arch: x86_64
+  summary: Small build system with a focus on speed
+  description: >-
+    This module includes Ninja build system. Ninja is a small build system with a
+    focus on speed. It differs from other build systems in two major respects: it
+    is designed to have its input files generated by a higher-level build system,
+    and it is designed to run builds as fast as possible.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/ninja.git?#6e64d7e4ddf96330ba0ecb2af6ff177342fb6554
+      commit: 6e64d7e4ddf96330ba0ecb2af6ff177342fb6554
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        ninja-build:
+          ref: e1503714b8eaa880edb8fa1643273c7363a7e42a
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://ninja-build.org/
+    documentation: https://ninja-build.org/manual.html
+    tracker: https://github.com/ninja-build/ninja/issues
+  profiles:
+    default:
+      rpms:
+      - ninja-build
+  api:
+    rpms:
+    - ninja-build
+  components:
+    rpms:
+      ninja-build:
+        rationale: Main component.
+        repository: git://pkgs.fedoraproject.org/rpms/ninja-build
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/ninja-build
+        ref: master
+  artifacts:
+    rpms:
+    - ninja-build-0:1.8.2-4.module_1991+4e5efe2f.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: mysql
+  stream: 5.7
+  version: 20180816141551
+  context: 6c81f848
+  arch: x86_64
+  summary: MySQL Module
+  description: >-
+    MySQL is a multi-user, multi-threaded SQL database server. MySQL is a client/server
+    implementation consisting of a server daemon (mysqld) and many different client
+    programs and libraries. The base package contains the standard MySQL client programs
+    and generic MySQL files.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2 with exceptions and LGPLv2 and BSD
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/mysql.git?#7708247d0b4d3a7502d8a3fd328f65be57f2efcf
+      commit: 7708247d0b4d3a7502d8a3fd328f65be57f2efcf
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        community-mysql:
+          ref: 58939b8918ec8d1d1d706190fab7e760817c0053
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/container-images/mariadb/
+    tracker: https://github.com/modularity-modules/mysql
+  profiles:
+    client:
+      rpms:
+      - community-mysql
+    default:
+      rpms:
+      - community-mysql
+      - community-mysql-server
+    server:
+      rpms:
+      - community-mysql-server
+  api:
+    rpms:
+    - community-mysql
+    - community-mysql-server
+  buildopts:
+    rpms:
+      macros: |
+        %runselftest 0
+  components:
+    rpms:
+      community-mysql:
+        rationale: MySQL package.
+        repository: git://pkgs.fedoraproject.org/rpms/community-mysql
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/community-mysql
+        ref: 58939b89
+        buildorder: 10
+  artifacts:
+    rpms:
+    - community-mysql-0:5.7.22-1.module_1723+91eca47f.x86_64
+    - community-mysql-common-0:5.7.22-1.module_1723+91eca47f.x86_64
+    - community-mysql-devel-0:5.7.22-1.module_1723+91eca47f.x86_64
+    - community-mysql-embedded-0:5.7.22-1.module_1723+91eca47f.x86_64
+    - community-mysql-embedded-devel-0:5.7.22-1.module_1723+91eca47f.x86_64
+    - community-mysql-errmsg-0:5.7.22-1.module_1723+91eca47f.x86_64
+    - community-mysql-libs-0:5.7.22-1.module_1723+91eca47f.x86_64
+    - community-mysql-server-0:5.7.22-1.module_1723+91eca47f.x86_64
+    - community-mysql-test-0:5.7.22-1.module_1723+91eca47f.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: mongodb
+  stream: 3.6
+  version: 20180601084133
+  context: 6c81f848
+  arch: x86_64
+  summary: MongoDB Module
+  description: >-
+    Mongo from humongous is a high-performance, open source, schema-free document-oriented
+    database. MongoDB is written in C++ and offers the following features. Collection
+    oriented storage, easy storage of object/JSON-style data. Dynamic queries. Full
+    index support, including on inner objects and embedded arrays. Query profiling.
+    Replication and fail-over support. Efficient storage of binary data including
+    large objects (e.g. photos and videos). Auto-sharding for cloud-level scalability
+    (currently in early alpha). Commercial Support Available. A key goal of MongoDB
+    is to bridge the gap between key/value stores (which are fast and highly scalable)
+    and traditional RDBMS systems (which are deep in functionality).
+  license:
+    module:
+    - MIT
+    content:
+    - AGPLv3 and zlib and ASL 2.0
+    - ASL 2.0
+    - ASL 2.0 and MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/mongodb.git?#a5dc17324f3dba53a00377cf0bbe7452c60c3759
+      commit: a5dc17324f3dba53a00377cf0bbe7452c60c3759
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        mongodb:
+          ref: 77494fb130cfc601d09294baf4d919f91b82fe28
+        python-pymongo:
+          ref: 3d4e2bc45d006ee50ca24db56f41a3e23cdbf044
+        mongo-java-driver:
+          ref: 2b02035c33706283bf7c67fa82b1d214916f8893
+        mongo-tools:
+          ref: eed3205ebb63aa71b62b59ce5788bbb434c85ded
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/container-images/mongodb/
+    tracker: https://github.com/modularity-modules/mongodb
+  profiles:
+    client:
+      rpms:
+      - mongo-tools
+      - mongodb
+    default:
+      rpms:
+      - mongodb
+      - mongodb-server
+    server:
+      rpms:
+      - mongodb-server
+  api:
+    rpms:
+    - mongo-tools
+    - mongodb
+    - mongodb-server
+  filter:
+    rpms:
+    - mongo-tools-devel
+  buildopts:
+    rpms:
+      macros: |
+        %with_bundled 1
+        %_with_xmvn_javadoc 1
+        %_with_jp_minimal 1
+  components:
+    rpms:
+      mongo-java-driver:
+        rationale: Java driver for MongoDB.
+        repository: git://pkgs.fedoraproject.org/rpms/mongo-java-driver
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/mongo-java-driver
+        ref: 3.6
+        buildorder: 2
+        arches: [aarch64, ppc64le, s390x, x86_64]
+      mongo-tools:
+        rationale: MongoDB tools.
+        repository: git://pkgs.fedoraproject.org/rpms/mongo-tools
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/mongo-tools
+        ref: 3.6
+        buildorder: 2
+        arches: [aarch64, ppc64le, s390x, x86_64]
+      mongodb:
+        rationale: MongoDB package.
+        repository: git://pkgs.fedoraproject.org/rpms/mongodb
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/mongodb
+        ref: 3.6
+        buildorder: 2
+        arches: [aarch64, ppc64le, s390x, x86_64]
+      python-pymongo:
+        rationale: Python MongoDB driver | MongoDB dependecy for running testsuite.
+        repository: git://pkgs.fedoraproject.org/rpms/python-pymongo
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-pymongo
+        ref: f28
+        buildorder: 3
+        arches: [aarch64, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - mongo-java-driver-0:3.6.3-1.module_1822+9f9b01c0.noarch
+    - mongo-java-driver-bson-0:3.6.3-1.module_1822+9f9b01c0.noarch
+    - mongo-java-driver-driver-0:3.6.3-1.module_1822+9f9b01c0.noarch
+    - mongo-java-driver-driver-async-0:3.6.3-1.module_1822+9f9b01c0.noarch
+    - mongo-java-driver-driver-core-0:3.6.3-1.module_1822+9f9b01c0.noarch
+    - mongo-java-driver-javadoc-0:3.6.3-1.module_1822+9f9b01c0.noarch
+    - mongo-tools-0:3.6.4-0.2.20180528gite657a1d.module_1806+7fc7744f.x86_64
+    - mongodb-0:3.6.4-2.module_1831+e8c1cdcd.x86_64
+    - mongodb-server-0:3.6.4-2.module_1831+e8c1cdcd.x86_64
+    - mongodb-test-0:3.6.4-2.module_1831+e8c1cdcd.x86_64
+    - python-pymongo-doc-0:3.6.1-1.module_1786+4c13601d.noarch
+    - python2-bson-0:3.6.1-1.module_1786+4c13601d.x86_64
+    - python2-pymongo-0:3.6.1-1.module_1786+4c13601d.x86_64
+    - python2-pymongo-gridfs-0:3.6.1-1.module_1786+4c13601d.x86_64
+    - python3-bson-0:3.6.1-1.module_1786+4c13601d.x86_64
+    - python3-pymongo-0:3.6.1-1.module_1786+4c13601d.x86_64
+    - python3-pymongo-gridfs-0:3.6.1-1.module_1786+4c13601d.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: mongodb
+  stream: 3.4
+  version: 20180601083501
+  context: 6c81f848
+  arch: x86_64
+  summary: MongoDB Module
+  description: >-
+    Mongo from humongous is a high-performance, open source, schema-free document-oriented
+    database. MongoDB is written in C++ and offers the following features. Collection
+    oriented storage, easy storage of object/JSON-style data. Dynamic queries. Full
+    index support, including on inner objects and embedded arrays. Query profiling.
+    Replication and fail-over support. Efficient storage of binary data including
+    large objects (e.g. photos and videos). Auto-sharding for cloud-level scalability
+    (currently in early alpha). Commercial Support Available. A key goal of MongoDB
+    is to bridge the gap between key/value stores (which are fast and highly scalable)
+    and traditional RDBMS systems (which are deep in functionality).
+  license:
+    module:
+    - MIT
+    content:
+    - AGPLv3 and zlib and ASL 2.0
+    - ASL 2.0 and MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/mongodb.git?#d3bc3e2e8b412da82dbd2d4f3a5f209ac47872fa
+      commit: d3bc3e2e8b412da82dbd2d4f3a5f209ac47872fa
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        mongodb:
+          ref: f94545073372dfb2d06446221e6bfc8b0ed7aeaf
+        python-pymongo:
+          ref: 3d4e2bc45d006ee50ca24db56f41a3e23cdbf044
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/container-images/mongodb/
+    tracker: https://github.com/modularity-modules/mongodb
+  profiles:
+    client:
+      rpms:
+      - mongodb
+    default:
+      rpms:
+      - mongodb
+      - mongodb-server
+    server:
+      rpms:
+      - mongodb-server
+  api:
+    rpms:
+    - mongodb
+    - mongodb-server
+  components:
+    rpms:
+      mongodb:
+        rationale: MongoDB package.
+        repository: git://pkgs.fedoraproject.org/rpms/mongodb
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/mongodb
+        ref: 3.4
+        buildorder: 2
+        arches: [aarch64, ppc64le, s390x, x86_64]
+      python-pymongo:
+        rationale: Python MongoDB driver | MongoDB dependecy for running testsuite.
+        repository: git://pkgs.fedoraproject.org/rpms/python-pymongo
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-pymongo
+        ref: f28
+        buildorder: 3
+        arches: [aarch64, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - mongodb-0:3.4.11-3.module_1829+95924ba0.x86_64
+    - mongodb-server-0:3.4.11-3.module_1829+95924ba0.x86_64
+    - mongodb-test-0:3.4.11-3.module_1829+95924ba0.x86_64
+    - python-pymongo-doc-0:3.6.1-1.module_1829+95924ba0.noarch
+    - python2-bson-0:3.6.1-1.module_1829+95924ba0.x86_64
+    - python2-pymongo-0:3.6.1-1.module_1829+95924ba0.x86_64
+    - python2-pymongo-gridfs-0:3.6.1-1.module_1829+95924ba0.x86_64
+    - python3-bson-0:3.6.1-1.module_1829+95924ba0.x86_64
+    - python3-pymongo-0:3.6.1-1.module_1829+95924ba0.x86_64
+    - python3-pymongo-gridfs-0:3.6.1-1.module_1829+95924ba0.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: meson
+  stream: master
+  version: 20180816151613
+  context: 06d0a27d
+  arch: x86_64
+  summary: The Meson Build system
+  description: >-
+    Meson is an open source build system meant to be both extremely fast, and, even
+    more importantly, as user friendly as possible.
+
+    The main design point of Meson is that every moment a developer spends writing
+    or debugging build definitions is a second wasted. So is every second spent waiting
+    for the build system to actually start compiling code.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/meson.git?#9826d0b55a3e90793ffee9e34aa17dd740b282e4
+      commit: 9826d0b55a3e90793ffee9e34aa17dd740b282e4
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        meson:
+          ref: d715e30e897f9fca5716dcb7b0a8a07ca3496d17
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      ninja: []
+      platform: [f29]
+  references:
+    community: https://mesonbuild.com/
+    documentation: https://mesonbuild.com/
+    tracker: https://github.com/mesonbuild/meson/issues
+  profiles:
+    default:
+      rpms:
+      - meson
+  api:
+    rpms:
+    - meson
+  components:
+    rpms:
+      meson:
+        rationale: Main component.
+        repository: git://pkgs.fedoraproject.org/rpms/meson
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/meson
+        ref: master
+  artifacts:
+    rpms:
+    - meson-0:0.47.1-5.module_1993+7c0a4d1e.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: maven
+  stream: 3.5
+  version: 20180629153919
+  context: 819b5873
+  arch: x86_64
+  summary: Java project management and project comprehension tool
+  description: >-
+    Maven is a software project management and comprehension tool. Based on the concept
+    of a project object model (POM), Maven can manage a project's build, reporting
+    and documentation from a central piece of information.
+  license:
+    module:
+    - MIT
+    content:
+    - (CDDL or GPLv2 with exceptions) and ASL 2.0
+    - ASL 1.1 and ASL 2.0 and xpp and BSD and Public Domain
+    - ASL 2.0
+    - ASL 2.0 and ASL 1.1 and MIT
+    - ASL 2.0 and EPL and BSD
+    - ASL 2.0 and MIT
+    - ASL 2.0 and Plexus
+    - CDDL or GPLv2 with exceptions
+    - EPL
+    - MIT
+    - MIT and ASL 2.0
+    - Public Domain
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/maven.git?#224ccb2073e8c2dbb83b28c864873e277a71c468
+      commit: 224ccb2073e8c2dbb83b28c864873e277a71c468
+      buildrequires:
+        javapackages-tools:
+          ref: 1e429a4d686d3fdd1d93ce7e8ac7254148ea3471
+          stream: 201801
+          context: b43b0c8f
+          version: 20180629150827
+          filtered_rpms: []
+        platform:
+          ref: virtual
+          stream: f28
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        plexus-classworlds:
+          ref: 3e4086fae3de5ed724e85ecef28f6ea73a43cf93
+        jansi:
+          ref: 4bdd2387b97de8352a0f7a976b7d8ccde8db0b24
+        aopalliance:
+          ref: 4218fdf5b21e46bcf80aa3baa4248945b5a06e27
+        sisu:
+          ref: 751afe29d8eda0029656309735ab884b58c1b37b
+        maven-wagon:
+          ref: 4652302afd7cc1a3d4eb48a1ae439bfc109daa90
+        maven-shared-utils:
+          ref: fc1e8b47ffa930bf339234332d594dfb957c1fb2
+        glassfish-el:
+          ref: 1ee218e03f1f7c4f9b282faa439f62aba1deae5f
+        plexus-cipher:
+          ref: 1a7a663ac4e50778d6e23a1b65235c12c7e422c4
+        guava20:
+          ref: 1a98ae8658f477148660ae11626acc5d3efcf88c
+        plexus-interpolation:
+          ref: 18ba33c0fff9697a243b9c495200ba68d36c1071
+        plexus-utils:
+          ref: 385b958ac294ee3b0851a885a2894b0de02a93b0
+        maven-resolver:
+          ref: 66d2e2fea8fd8bcd9a297e5a550d2fcc87cc49e4
+        maven:
+          ref: 666068fe9c979f42c7ca3d84583b0838985179b3
+        jsoup:
+          ref: abe894a4ebec945ad4c2332084b687d1311ef15b
+        httpcomponents-core:
+          ref: 8be6b3645b3bad6f73fe1e21a7a9a25ae286a016
+        apache-commons-lang3:
+          ref: aa5729029ca5b7859792bc50a0b3f12ac53c2faf
+        plexus-sec-dispatcher:
+          ref: a8ba97007fcb427a1d7eb066e8d61fa90062b17b
+        apache-commons-codec:
+          ref: b1a8636df2b288f5aa1b2b5bdff1a17b1174f175
+        slf4j:
+          ref: d7cd96bc7a8e8d8d62c8bc62baa7df02cef56c63
+        plexus-containers:
+          ref: 94ad5fd40f32db2b4ad5432ed568306f1e8b38ae
+        cdi-api:
+          ref: ff9f653d6435f240bb8a390ff9f99dfb578d42b8
+        apache-commons-io:
+          ref: 817444e3e10e4d2422e6541f22c86eb281a3145c
+        httpcomponents-client:
+          ref: 4eb97a2f3fa38a0cc50ced7f913346788172d5c6
+        geronimo-annotation:
+          ref: b32597766edae5bbdd797f04297642231756af8c
+        google-guice:
+          ref: 7e0365f95c46ad40ca084720b0a80afc40447d99
+        atinject:
+          ref: 4762f5de60627d6d61131dd41a7d9b5027c4e300
+        apache-commons-logging:
+          ref: 4d8596c64b6c0951b0e8f511d5c067f81b393e5d
+        jansi-native:
+          ref: 544b397797de885ca9b65442a4f956f817b76ddc
+        hawtjni:
+          ref: 93281e0174d79dfd549e57818292b1cbec5a7703
+        apache-commons-cli:
+          ref: 624d058960641b73418257250e9c1441d9f7c3e6
+        jboss-interceptors-1.2-api:
+          ref: ac58213ab9bf09451d82896b60eb822e788e777e
+  dependencies:
+  - requires:
+      platform: []
+  profiles:
+    default:
+      rpms:
+      - maven
+  api:
+    rpms:
+    - maven
+  filter:
+    rpms:
+    - aopalliance-javadoc
+    - apache-commons-cli-javadoc
+    - apache-commons-codec-javadoc
+    - apache-commons-io-javadoc
+    - apache-commons-lang3-javadoc
+    - apache-commons-logging-javadoc
+    - atinject-javadoc
+    - atinject-tck
+    - cdi-api-javadoc
+    - geronimo-annotation-javadoc
+    - glassfish-el
+    - glassfish-el-javadoc
+    - google-guice-javadoc
+    - guava20-javadoc
+    - guava20-testlib
+    - guice-assistedinject
+    - guice-bom
+    - guice-extensions
+    - guice-grapher
+    - guice-jmx
+    - guice-jndi
+    - guice-multibindings
+    - guice-parent
+    - guice-servlet
+    - guice-testlib
+    - guice-throwingproviders
+    - hawtjni
+    - hawtjni-javadoc
+    - httpcomponents-client-cache
+    - httpcomponents-client-javadoc
+    - httpcomponents-core-javadoc
+    - jansi-javadoc
+    - jansi-native-javadoc
+    - jboss-interceptors-1.2-api-javadoc
+    - jsoup-javadoc
+    - jul-to-slf4j
+    - log4j-over-slf4j
+    - maven-hawtjni-plugin
+    - maven-javadoc
+    - maven-resolver
+    - maven-resolver-javadoc
+    - maven-resolver-test-util
+    - maven-resolver-transport-classpath
+    - maven-resolver-transport-file
+    - maven-resolver-transport-http
+    - maven-shared-utils-javadoc
+    - maven-wagon
+    - maven-wagon-ftp
+    - maven-wagon-http-lightweight
+    - maven-wagon-javadoc
+    - maven-wagon-providers
+    - plexus-cipher-javadoc
+    - plexus-classworlds-javadoc
+    - plexus-containers
+    - plexus-containers-component-javadoc
+    - plexus-containers-component-metadata
+    - plexus-containers-container-default
+    - plexus-containers-javadoc
+    - plexus-interpolation-javadoc
+    - plexus-sec-dispatcher-javadoc
+    - plexus-utils-javadoc
+    - sisu-javadoc
+    - slf4j-ext
+    - slf4j-javadoc
+    - slf4j-jcl
+    - slf4j-jdk14
+    - slf4j-log4j12
+    - slf4j-manual
+    - slf4j-sources
+  buildopts:
+    rpms:
+      macros: |
+        %_with_xmvn_javadoc 1
+        %_without_asciidoc 1
+        %_without_avalon 1
+        %_without_bouncycastle 1
+        %_without_cython 1
+        %_without_dafsa 1
+        %_without_desktop 1
+        %_without_doxygen 1
+        %_without_dtd 1
+        %_without_eclipse 1
+        %_without_ehcache 1
+        %_without_emacs 1
+        %_without_equinox 1
+        %_without_fop 1
+        %_without_ftp 1
+        %_without_gradle 1
+        %_without_groovy 1
+        %_without_hadoop 1
+        %_without_hsqldb 1
+        %_without_itext 1
+        %_without_jackson 1
+        %_without_jmh 1
+        %_without_jna 1
+        %_without_jpa 1
+        %_without_junit5 1
+        %_without_logback 1
+        %_without_markdown 1
+        %_without_memcached 1
+        %_without_memoryfilesystem 1
+        %_without_obr 1
+        %_without_python 1
+        %_without_reporting 1
+        %_without_scm 1
+        %_without_snappy 1
+        %_without_spring 1
+        %_without_ssh 1
+        %_without_testlib 1
+  components:
+    rpms:
+      aopalliance:
+        rationale: 'Runtime dependency of google-guice, maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/aopalliance
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/aopalliance
+        ref: javapackages
+        buildorder: 10
+      apache-commons-cli:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/apache-commons-cli
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/apache-commons-cli
+        ref: javapackages
+        buildorder: 10
+      apache-commons-codec:
+        rationale: 'Runtime dependency of httpcomponents-client, maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/apache-commons-codec
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/apache-commons-codec
+        ref: javapackages
+        buildorder: 10
+      apache-commons-io:
+        rationale: "Runtime dependency of maven, maven-shared-utils,\n     maven-wagon.\n"
+        repository: git://pkgs.fedoraproject.org/rpms/apache-commons-io
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/apache-commons-io
+        ref: javapackages
+        buildorder: 10
+      apache-commons-lang3:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/apache-commons-lang3
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/apache-commons-lang3
+        ref: javapackages
+        buildorder: 10
+      apache-commons-logging:
+        rationale: 'Runtime dependency of httpcomponents-client, maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/apache-commons-logging
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/apache-commons-logging
+        ref: javapackages
+        buildorder: 10
+      atinject:
+        rationale: 'Runtime dependency of cdi-api, google-guice, maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/atinject
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/atinject
+        ref: javapackages
+        buildorder: 10
+      cdi-api:
+        rationale: 'Runtime dependency of maven, sisu.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/cdi-api
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/cdi-api
+        ref: javapackages
+        buildorder: 20
+      geronimo-annotation:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/geronimo-annotation
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/geronimo-annotation
+        ref: javapackages
+        buildorder: 10
+      glassfish-el:
+        rationale: 'Runtime dependency of cdi-api.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/glassfish-el
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/glassfish-el
+        ref: javapackages
+        buildorder: 10
+      google-guice:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/google-guice
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/google-guice
+        ref: javapackages
+        buildorder: 20
+      guava20:
+        rationale: 'Runtime dependency of google-guice, maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/guava20
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/guava20
+        ref: javapackages
+        buildorder: 10
+      hawtjni:
+        rationale: 'Runtime dependency of jansi, jansi-native, maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/hawtjni
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/hawtjni
+        ref: javapackages
+        buildorder: 10
+      httpcomponents-client:
+        rationale: 'Runtime dependency of maven, maven-wagon.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/httpcomponents-client
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/httpcomponents-client
+        ref: javapackages
+        buildorder: 20
+      httpcomponents-core:
+        rationale: "Runtime dependency of httpcomponents-client, maven,\n     maven-wagon.\n"
+        repository: git://pkgs.fedoraproject.org/rpms/httpcomponents-core
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/httpcomponents-core
+        ref: javapackages
+        buildorder: 10
+      jansi:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/jansi
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/jansi
+        ref: javapackages
+        buildorder: 30
+      jansi-native:
+        rationale: 'Runtime dependency of jansi, maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/jansi-native
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/jansi-native
+        ref: javapackages
+        buildorder: 20
+      jboss-interceptors-1.2-api:
+        rationale: 'Runtime dependency of cdi-api.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/jboss-interceptors-1.2-api
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/jboss-interceptors-1.2-api
+        ref: javapackages
+        buildorder: 10
+      jsoup:
+        rationale: 'Runtime dependency of maven-wagon.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/jsoup
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/jsoup
+        ref: javapackages
+        buildorder: 10
+      maven:
+        rationale: 'Module API.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/maven
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/maven
+        ref: javapackages
+        buildorder: 50
+      maven-resolver:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/maven-resolver
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/maven-resolver
+        ref: javapackages
+        buildorder: 40
+      maven-shared-utils:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/maven-shared-utils
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/maven-shared-utils
+        ref: javapackages
+        buildorder: 20
+      maven-wagon:
+        rationale: 'Runtime dependency of maven, maven-resolver.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/maven-wagon
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/maven-wagon
+        ref: javapackages
+        buildorder: 30
+      plexus-cipher:
+        rationale: 'Runtime dependency of maven, plexus-sec-dispatcher.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/plexus-cipher
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/plexus-cipher
+        ref: javapackages
+        buildorder: 10
+      plexus-classworlds:
+        rationale: 'Runtime dependency of maven, sisu.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/plexus-classworlds
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/plexus-classworlds
+        ref: javapackages
+        buildorder: 10
+      plexus-containers:
+        rationale: 'Runtime dependency of maven, sisu.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/plexus-containers
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/plexus-containers
+        ref: javapackages
+        buildorder: 10
+      plexus-interpolation:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/plexus-interpolation
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/plexus-interpolation
+        ref: javapackages
+        buildorder: 10
+      plexus-sec-dispatcher:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/plexus-sec-dispatcher
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/plexus-sec-dispatcher
+        ref: javapackages
+        buildorder: 20
+      plexus-utils:
+        rationale: "Runtime dependency of maven, maven-wagon,\n     plexus-sec-dispatcher,
+          sisu.\n"
+        repository: git://pkgs.fedoraproject.org/rpms/plexus-utils
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/plexus-utils
+        ref: javapackages
+        buildorder: 10
+      sisu:
+        rationale: 'Runtime dependency of maven.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/sisu
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/sisu
+        ref: javapackages
+        buildorder: 30
+      slf4j:
+        rationale: 'Runtime dependency of maven, maven-wagon.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/slf4j
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/slf4j
+        ref: javapackages
+        buildorder: 10
+  artifacts:
+    rpms:
+    - aopalliance-0:1.0-17.module_1885+a6f9b3e6.noarch
+    - apache-commons-cli-0:1.4-4.module_1885+a6f9b3e6.noarch
+    - apache-commons-codec-0:1.11-3.module_1885+a6f9b3e6.noarch
+    - apache-commons-io-1:2.6-3.module_1885+a6f9b3e6.noarch
+    - apache-commons-lang3-0:3.7-3.module_1885+a6f9b3e6.noarch
+    - apache-commons-logging-0:1.2-13.module_1885+a6f9b3e6.noarch
+    - atinject-0:1-28.20100611svn86.module_1885+a6f9b3e6.noarch
+    - cdi-api-0:1.2-8.module_1885+a6f9b3e6.noarch
+    - geronimo-annotation-0:1.0-23.module_1885+a6f9b3e6.noarch
+    - glassfish-el-api-0:3.0.1-0.7.b08.module_1885+a6f9b3e6.noarch
+    - google-guice-0:4.1-11.module_1885+a6f9b3e6.noarch
+    - guava20-0:20.0-6.module_1885+a6f9b3e6.noarch
+    - hawtjni-runtime-0:1.16-1.module_1885+a6f9b3e6.noarch
+    - httpcomponents-client-0:4.5.5-4.module_1885+a6f9b3e6.noarch
+    - httpcomponents-core-0:4.4.9-4.module_1885+a6f9b3e6.noarch
+    - jansi-0:1.17.1-1.module_1885+a6f9b3e6.noarch
+    - jansi-native-0:1.7-5.module_1885+a6f9b3e6.x86_64
+    - jboss-interceptors-1.2-api-0:1.0.0-8.module_1885+a6f9b3e6.noarch
+    - jcl-over-slf4j-0:1.7.25-4.module_1885+a6f9b3e6.noarch
+    - jsoup-0:1.11.3-1.module_1885+a6f9b3e6.noarch
+    - maven-1:3.5.4-1.module_1885+a6f9b3e6.noarch
+    - maven-lib-1:3.5.4-1.module_1885+a6f9b3e6.noarch
+    - maven-resolver-api-1:1.1.1-2.module_1885+a6f9b3e6.noarch
+    - maven-resolver-connector-basic-1:1.1.1-2.module_1885+a6f9b3e6.noarch
+    - maven-resolver-impl-1:1.1.1-2.module_1885+a6f9b3e6.noarch
+    - maven-resolver-spi-1:1.1.1-2.module_1885+a6f9b3e6.noarch
+    - maven-resolver-transport-wagon-1:1.1.1-2.module_1885+a6f9b3e6.noarch
+    - maven-resolver-util-1:1.1.1-2.module_1885+a6f9b3e6.noarch
+    - maven-shared-utils-0:3.2.1-0.1.module_1885+a6f9b3e6.noarch
+    - maven-wagon-file-0:3.1.0-1.module_1885+a6f9b3e6.noarch
+    - maven-wagon-http-0:3.1.0-1.module_1885+a6f9b3e6.noarch
+    - maven-wagon-http-shared-0:3.1.0-1.module_1885+a6f9b3e6.noarch
+    - maven-wagon-provider-api-0:3.1.0-1.module_1885+a6f9b3e6.noarch
+    - plexus-cipher-0:1.7-14.module_1885+a6f9b3e6.noarch
+    - plexus-classworlds-0:2.5.2-9.module_1885+a6f9b3e6.noarch
+    - plexus-containers-component-annotations-0:1.7.1-6.module_1885+a6f9b3e6.noarch
+    - plexus-interpolation-0:1.22-9.module_1885+a6f9b3e6.noarch
+    - plexus-sec-dispatcher-0:1.4-24.module_1885+a6f9b3e6.noarch
+    - plexus-utils-0:3.1.0-1.module_1885+a6f9b3e6.noarch
+    - sisu-inject-1:0.3.3-3.module_1885+a6f9b3e6.noarch
+    - sisu-plexus-1:0.3.3-3.module_1885+a6f9b3e6.noarch
+    - slf4j-0:1.7.25-4.module_1885+a6f9b3e6.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: mariadb
+  stream: 10.1
+  version: 20180418185803
+  context: 6c81f848
+  arch: x86_64
+  summary: MariaDB Module
+  description: >-
+    MariaDB is a community developed branch of MySQL. MariaDB is a multi-user, multi-threaded
+    SQL database server. It is a client/server implementation consisting of a server
+    daemon (mysqld) and many different client programs and libraries. The base package
+    contains the standard MariaDB/MySQL client programs and generic MySQL files.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2 with exceptions and LGPLv2 and BSD
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/mariadb.git?#f1a4b73cfe2b0231ea125e96a64f0daf879245ee
+      commit: f1a4b73cfe2b0231ea125e96a64f0daf879245ee
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        mariadb:
+          ref: 76a52e56ed214544537575d3535615be3a7afd2f
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/container-images/mariadb/
+    tracker: https://github.com/modularity-modules/mariadb
+  profiles:
+    client:
+      rpms:
+      - mariadb
+    default:
+      rpms:
+      - mariadb
+      - mariadb-server
+    server:
+      rpms:
+      - mariadb-server
+  api:
+    rpms:
+    - mariadb
+    - mariadb-server
+  filter:
+    rpms:
+    - mariadb-bench
+    - mariadb-server-galera
+  buildopts:
+    rpms:
+      macros: |
+        %runselftest 0
+  components:
+    rpms:
+      mariadb:
+        rationale: MariaDB  package.
+        repository: git://pkgs.fedoraproject.org/rpms/mariadb
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/mariadb
+        ref: 76a52e56
+  artifacts:
+    rpms:
+    - mariadb-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-common-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-config-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-connect-engine-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-devel-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-embedded-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-embedded-devel-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-errmsg-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-libs-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-oqgraph-engine-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-server-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-server-utils-3:10.1.30-2.module_1690+8f54252c.x86_64
+    - mariadb-test-3:10.1.30-2.module_1690+8f54252c.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: lizardfs
+  stream: devel
+  version: 20180816140845
+  context: 6c81f848
+  arch: x86_64
+  summary: Distributed, fault tolerant file system
+  description: >-
+    LizardFS is an Open Source, easy to deploy and maintain, distributed, fault tolerant
+    file system for POSIX compliant OSes. LizardFS is a fork of MooseFS. For more
+    information please visit http://lizardfs.com
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv3 and ASL 2.0 and Boost
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/lizardfs.git?#1e4d151b55a4c460cd15f0b6182499db374afd41
+      commit: 1e4d151b55a4c460cd15f0b6182499db374afd41
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        lizardfs:
+          ref: 0624af153ffd409f2f7b3c3f63fd2b5e5f571cd0
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  components:
+    rpms:
+      lizardfs:
+        rationale: Provides the core functionality.
+        repository: git://pkgs.fedoraproject.org/rpms/lizardfs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/lizardfs
+        ref: devel
+  artifacts:
+    rpms:
+    - lizardfs-adm-0:3.13.0-0.rc1r1.module_1987+e7db591a.x86_64
+    - lizardfs-cgi-0:3.13.0-0.rc1r1.module_1987+e7db591a.x86_64
+    - lizardfs-cgiserv-0:3.13.0-0.rc1r1.module_1987+e7db591a.x86_64
+    - lizardfs-chunkserver-0:3.13.0-0.rc1r1.module_1987+e7db591a.x86_64
+    - lizardfs-client-0:3.13.0-0.rc1r1.module_1987+e7db591a.x86_64
+    - lizardfs-master-0:3.13.0-0.rc1r1.module_1987+e7db591a.x86_64
+    - lizardfs-metalogger-0:3.13.0-0.rc1r1.module_1987+e7db591a.x86_64
+    - lizardfs-uraft-0:3.13.0-0.rc1r1.module_1987+e7db591a.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: libgit2
+  stream: 0.27
+  version: 20180926125215
+  context: 6c81f848
+  arch: x86_64
+  summary: Library implementation of Git
+  description: >-
+    The Git linkable library.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2 with exceptions
+    - GPLv2 with linking exception
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/libgit2.git?#26f667d35d80726e876c7aa53f5a823b1b99f591
+      commit: 26f667d35d80726e876c7aa53f5a823b1b99f591
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        libgit2:
+          ref: 31dd08f7296121e04d3bdf7ef1f28b5ec434999d
+        python-pygit2:
+          ref: 2c97c77dce9d2c76bfda1bf5e21420f24b242bbf
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://libgit2.org/
+  api:
+    rpms:
+    - libgit2
+    - libgit2-devel
+  components:
+    rpms:
+      libgit2:
+        rationale: Main component.
+        repository: git+https://src.fedoraproject.org/rpms/libgit2
+        cache: https://src.fedoraproject.org/repo/pkgs/libgit2
+        ref: 0.27
+      python-pygit2:
+        rationale: Main component.
+        repository: git+https://src.fedoraproject.org/rpms/python-pygit2
+        cache: https://src.fedoraproject.org/repo/pkgs/python-pygit2
+        ref: 0.27
+        buildorder: 10
+  artifacts:
+    rpms:
+    - libgit2-0:0.27.4-1.module_2222+9bfbc8d7.x86_64
+    - libgit2-devel-0:0.27.4-1.module_2222+9bfbc8d7.x86_64
+    - python-pygit2-doc-0:0.27.2-1.module_2222+9bfbc8d7.noarch
+    - python2-pygit2-0:0.27.2-1.module_2222+9bfbc8d7.x86_64
+    - python3-pygit2-0:0.27.2-1.module_2222+9bfbc8d7.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: libgit2
+  stream: 0.26
+  version: 20180928101841
+  context: 6c81f848
+  arch: x86_64
+  summary: Library implementation of Git
+  description: >-
+    The Git linkable library.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2 with exceptions
+    - GPLv2 with linking exception
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/libgit2.git?#f4047980866675cc57931906fd1e5ff0577d57a4
+      commit: f4047980866675cc57931906fd1e5ff0577d57a4
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        libgit2:
+          ref: fb4d3ef3432b26c0db70fbf6d5bb82854f25d352
+        python-pygit2:
+          ref: 05ad050af7950a262d711e8c1c29a84e87087073
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://libgit2.org/
+  api:
+    rpms:
+    - libgit2
+    - libgit2-devel
+  components:
+    rpms:
+      libgit2:
+        rationale: Main component.
+        repository: git+https://src.fedoraproject.org/rpms/libgit2
+        cache: https://src.fedoraproject.org/repo/pkgs/libgit2
+        ref: 0.26
+      python-pygit2:
+        rationale: Main component.
+        repository: git+https://src.fedoraproject.org/rpms/python-pygit2
+        cache: https://src.fedoraproject.org/repo/pkgs/python-pygit2
+        ref: 0.26
+        buildorder: 10
+  artifacts:
+    rpms:
+    - libgit2-0:0.26.6-1.module_2241+da9f6017.x86_64
+    - libgit2-devel-0:0.26.6-1.module_2241+da9f6017.x86_64
+    - python-pygit2-doc-0:0.26.4-1.module_2241+da9f6017.noarch
+    - python2-pygit2-0:0.26.4-1.module_2241+da9f6017.x86_64
+    - python3-pygit2-0:0.26.4-1.module_2241+da9f6017.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: kubernetes
+  stream: openshift-3.10
+  version: 20180827171820
+  context: 6c81f848
+  arch: x86_64
+  summary: OpenShift Container Management
+  description: >-
+    OpenShift Origin is a distribution of Kubernetes optimized for application development
+    and deployment. OpenShift Origin adds developer and operational centric tools
+    on top of Kubernetes to enable rapid application development, easy deployment
+    and scaling, and long-term lifecycle maintenance for small and large teams and
+    applications. It provides a secure and multi-tenant configuration for Kubernetes
+    allowing you to safely host many different applications and workloads.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/kubernetes.git?#d90e9f3651d44c399a06273f01228ddb6d87c4f3
+      commit: d90e9f3651d44c399a06273f01228ddb6d87c4f3
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        origin:
+          ref: cd304ee543d2d0863c3b162697cbc2b94745802f
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://github.com/kubernetes/kubernetes
+    documentation: https://github.com/kubernetes/kubernetes
+    tracker: https://github.com/kubernetes/kubernetes
+  profiles:
+    default:
+      rpms:
+      - origin
+      - origin-clients
+      - origin-cluster-capacity
+      - origin-docker-excluder
+      - origin-dockerregistry
+      - origin-excluder
+      - origin-federation-services
+      - origin-master
+      - origin-node
+      - origin-pod
+      - origin-sdn-ovs
+      - origin-service-catalog
+      - origin-template-service-broker
+      - origin-tests
+      - origin-web-console
+  api:
+    rpms:
+    - origin
+  buildopts:
+    rpms:
+      macros: |
+        %_with_ignore_tests 1
+  components:
+    rpms:
+      origin:
+        rationale: Primary module component.
+        repository: git+https://src.fedoraproject.org/rpms/origin
+        cache: https://src.fedoraproject.org/repo/pkgs/origin
+        ref: openshift-3.10
+  artifacts:
+    rpms:
+    - origin-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-clients-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-cluster-capacity-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-docker-excluder-0:3.10.0-1.module_2135+dcc9a197.noarch
+    - origin-dockerregistry-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-excluder-0:3.10.0-1.module_2135+dcc9a197.noarch
+    - origin-federation-services-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-master-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-node-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-pod-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-sdn-ovs-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-service-catalog-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-template-service-broker-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-tests-0:3.10.0-1.module_2135+dcc9a197.x86_64
+    - origin-web-console-0:3.10.0-1.module_2135+dcc9a197.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: kubernetes
+  stream: 1.10
+  version: 20180827150115
+  context: 6c81f848
+  arch: x86_64
+  summary: Container cluster management
+  description: >-
+    Kubernetes is an open source system for managing containerized applications across
+    multiple hosts; providing basic mechanisms for deployment, maintenance, and scaling
+    of applications. Kubernetes builds upon a decade and a half of experience at Google
+    running production workloads at scale using a system called Borg, combined with
+    best-of-breed ideas and practices from the community.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/kubernetes.git?#98c4546e08fdd6b6adf3d9dc35d374becffc2116
+      commit: 98c4546e08fdd6b6adf3d9dc35d374becffc2116
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        kubernetes:
+          ref: 41689fd5bb5de3125b738270c51c81ccd4b26dd7
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://github.com/kubernetes/kubernetes
+    documentation: https://github.com/kubernetes/kubernetes
+    tracker: https://github.com/kubernetes/kubernetes
+  profiles:
+    default:
+      rpms:
+      - kubernetes
+      - kubernetes-client
+      - kubernetes-kubeadm
+      - kubernetes-master
+      - kubernetes-node
+  api:
+    rpms:
+    - kubernetes
+  buildopts:
+    rpms:
+      macros: |
+        %_with_ignore_tests 1
+  components:
+    rpms:
+      kubernetes:
+        rationale: Primary module component.
+        repository: git+https://src.fedoraproject.org/rpms/kubernetes
+        cache: https://src.fedoraproject.org/repo/pkgs/kubernetes
+        ref: 1.10
+  artifacts:
+    rpms:
+    - kubernetes-0:1.10.3-1.module_2132+faf1362b.x86_64
+    - kubernetes-client-0:1.10.3-1.module_2132+faf1362b.x86_64
+    - kubernetes-devel-0:1.10.3-1.module_2132+faf1362b.noarch
+    - kubernetes-kubeadm-0:1.10.3-1.module_2132+faf1362b.x86_64
+    - kubernetes-master-0:1.10.3-1.module_2132+faf1362b.x86_64
+    - kubernetes-node-0:1.10.3-1.module_2132+faf1362b.x86_64
+    - kubernetes-unit-test-0:1.10.3-1.module_2132+faf1362b.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: hub
+  stream: pre-release
+  version: 20180816140655
+  context: 6c81f848
+  arch: x86_64
+  summary: A command-line wrapper for git with github shortcuts
+  description: >-
+    hub is a command line tool that wraps `git` in order to extend it with extra features
+    and commands that make working with GitHub easier.
+
+        $ hub clone rtomayko/tilt
+
+        # expands to:
+        $ git clone git://github.com/rtomayko/tilt.git
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/hub.git?#44bb53f774b6561906da5d069b055fa2b02a38ef
+      commit: 44bb53f774b6561906da5d069b055fa2b02a38ef
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        hub:
+          ref: 65f4d09cbf742ef0bb58cf0a9b8c7d1c05295492
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://hub.github.com
+    documentation: https://hub.github.com
+    tracker: https://github.com/github/hub/issues
+  profiles:
+    default:
+      rpms:
+      - hub
+  api:
+    rpms:
+    - hub
+  components:
+    rpms:
+      hub:
+        rationale: A command-line wrapper for git with github shortcuts
+        repository: git://pkgs.fedoraproject.org/rpms/hub
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/hub
+        ref: pre-release
+  artifacts:
+    rpms:
+    - hub-0:prerelease-8.module_1978+3584bea7.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: golang-ecosystem
+  stream: 2018.0
+  version: 20180816154327
+  context: cbfb2833
+  arch: x86_64
+  summary: The ecosystem of packages for the Go programming language
+  description: >-
+    This module contains golang based tools used as dependencies for other packages,
+    for instance, go-md2man, a manpage converter written in Go, along with rpm macros
+    for building Go based tools.
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+    - GPLv3+
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/golang-ecosystem.git?#1654fad1d9abf46a7d4f7845ea9e847b762f08a5
+      commit: 1654fad1d9abf46a7d4f7845ea9e847b762f08a5
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        golang:
+          ref: 92882e9696b779110fd27aa11ddbc88f30eb82a2
+          stream: 1.10
+          context: 6c81f848
+          version: 20180816140129
+          filtered_rpms: []
+      rpms:
+        go-srpm-macros:
+          ref: 4f85e708533960d6edfcb6e4eef29be758b25087
+        go-compilers:
+          ref: f40831872a58d2b2b28219d8ddf2931cb2f0bc2e
+        golang-github-russross-blackfriday:
+          ref: 5b8c2ba534b8019529df9d58b92027c6a976b40e
+        golang-github-cpuguy83-go-md2man:
+          ref: 5cdf8051cae5c0596f975d526ac476e6fb4ad5f0
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://github.com/golang-github-cpuguy83-go-md2man
+    documentation: https://github.com/golang-github-cpuguy83-go-md2man
+    tracker: https://github.com/golang-github-cpuguy83-go-md2man
+  profiles:
+    default:
+      rpms:
+      - go-compilers
+      - go-srpm-macros
+      - golang-github-cpuguy83-go-md2man
+      - golang-github-russross-blackfriday
+  api:
+    rpms:
+    - go-compilers-golang-compiler
+    - go-srpm-macros
+    - golang-github-cpuguy83-go-md2man
+  buildopts:
+    rpms:
+      macros: |
+        %_with_ignore_tests 1
+  components:
+    rpms:
+      go-compilers:
+        rationale: Build dependency for Go packages.
+        repository: git://pkgs.fedoraproject.org/rpms/go-compilers
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/go-compilers
+        ref: f28
+      go-srpm-macros:
+        rationale: Build dependency for Go packages.
+        repository: git://pkgs.fedoraproject.org/rpms/go-srpm-macros
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/go-srpm-macros
+        ref: f28
+        buildorder: 1
+      golang-github-cpuguy83-go-md2man:
+        rationale: Primary component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/golang-github-cpuguy83-go-md2man
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/golang-github-cpuguy83-go-md2man
+        ref: f28
+        buildorder: 3
+      golang-github-russross-blackfriday:
+        rationale: Build dependency for go-md2man.
+        repository: git://pkgs.fedoraproject.org/rpms/golang-github-russross-blackfriday
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/golang-github-russross-blackfriday
+        ref: f28
+        buildorder: 2
+  artifacts:
+    rpms:
+    - go-compilers-golang-compiler-0:1-30.module_1812+d7358d9b.x86_64
+    - go-srpm-macros-0:2-17.module_1812+d7358d9b.noarch
+    - golang-github-cpuguy83-go-md2man-0:1.0.7-6.20180307git1d903dc.module_2094+e5918054.x86_64
+    - golang-github-cpuguy83-go-md2man-devel-0:1.0.7-6.20180307git1d903dc.module_2094+e5918054.noarch
+    - golang-github-russross-blackfriday-devel-0:2.0.0-2.20180628git55d61fa.module_2094+e5918054.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: golang-ecosystem
+  stream: 2017.0
+  version: 20180816154241
+  context: cbfb2833
+  arch: x86_64
+  summary: The ecosystem of packages for the Go programming language
+  description: >-
+    This module contains golang based tools used as dependencies for other packages,
+    for instance, go-md2man, a manpage converter written in Go, along with rpm macros
+    for building Go based tools.
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+    - GPLv3+
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/golang-ecosystem.git?#384b17a75c5c9be71c913651126d6899e42e8d84
+      commit: 384b17a75c5c9be71c913651126d6899e42e8d84
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        golang:
+          ref: 92882e9696b779110fd27aa11ddbc88f30eb82a2
+          stream: 1.10
+          context: 6c81f848
+          version: 20180816140129
+          filtered_rpms: []
+      rpms:
+        go-srpm-macros:
+          ref: 4f85e708533960d6edfcb6e4eef29be758b25087
+        go-compilers:
+          ref: f40831872a58d2b2b28219d8ddf2931cb2f0bc2e
+        golang-github-russross-blackfriday:
+          ref: 5b8c2ba534b8019529df9d58b92027c6a976b40e
+        golang-github-cpuguy83-go-md2man:
+          ref: 5cdf8051cae5c0596f975d526ac476e6fb4ad5f0
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://github.com/golang-github-cpuguy83-go-md2man
+    documentation: https://github.com/golang-github-cpuguy83-go-md2man
+    tracker: https://github.com/golang-github-cpuguy83-go-md2man
+  profiles:
+    default:
+      rpms:
+      - go-compilers
+      - go-srpm-macros
+      - golang-github-cpuguy83-go-md2man
+      - golang-github-russross-blackfriday
+  api:
+    rpms:
+    - go-compilers-golang-compiler
+    - go-srpm-macros
+    - golang-github-cpuguy83-go-md2man
+  buildopts:
+    rpms:
+      macros: |
+        %_with_ignore_tests 1
+  components:
+    rpms:
+      go-compilers:
+        rationale: Build dependency for Go packages.
+        repository: git://pkgs.fedoraproject.org/rpms/go-compilers
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/go-compilers
+        ref: f28
+      go-srpm-macros:
+        rationale: Build dependency for Go packages.
+        repository: git://pkgs.fedoraproject.org/rpms/go-srpm-macros
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/go-srpm-macros
+        ref: f28
+        buildorder: 1
+      golang-github-cpuguy83-go-md2man:
+        rationale: Primary component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/golang-github-cpuguy83-go-md2man
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/golang-github-cpuguy83-go-md2man
+        ref: f28
+        buildorder: 3
+      golang-github-russross-blackfriday:
+        rationale: Build dependency for go-md2man.
+        repository: git://pkgs.fedoraproject.org/rpms/golang-github-russross-blackfriday
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/golang-github-russross-blackfriday
+        ref: f28
+        buildorder: 2
+  artifacts:
+    rpms:
+    - go-compilers-golang-compiler-0:1-30.module_1941+86fd1e0a.x86_64
+    - go-srpm-macros-0:2-17.module_1941+86fd1e0a.noarch
+    - golang-github-cpuguy83-go-md2man-0:1.0.7-6.20180307git1d903dc.module_1941+86fd1e0a.x86_64
+    - golang-github-cpuguy83-go-md2man-devel-0:1.0.7-6.20180307git1d903dc.module_1941+86fd1e0a.noarch
+    - golang-github-russross-blackfriday-devel-0:2.0.0-2.20180628git55d61fa.module_1941+86fd1e0a.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: golang
+  stream: 1.10
+  version: 20180816140129
+  context: 6c81f848
+  arch: x86_64
+  summary: The Go Programming Language
+  description: >-
+    This module provides the Go compiler and associated tools and documentation.
+  license:
+    module:
+    - MIT
+    content:
+    - BSD and Public Domain
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/golang.git?#92882e9696b779110fd27aa11ddbc88f30eb82a2
+      commit: 92882e9696b779110fd27aa11ddbc88f30eb82a2
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        golang:
+          ref: c333e76e869a626eb5936d311dc4ba4c29a10e09
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://groups.google.com/forum/#!forum/golang-nuts
+    documentation: https://golang.org/doc
+    tracker: https://github.com/golang/go/issues
+  profiles:
+    default:
+      rpms:
+      - golang
+  api:
+    rpms:
+    - golang
+    - golang-bin
+    - golang-docs
+    - golang-misc
+    - golang-race
+    - golang-shared
+    - golang-src
+    - golang-tests
+  buildopts:
+    rpms:
+      macros: |
+        %_with_ignore_tests 1
+  components:
+    rpms:
+      golang:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/golang
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/golang
+        ref: f28
+  artifacts:
+    rpms:
+    - golang-0:1.10.3-1.module_2044+a37cc272.x86_64
+    - golang-bin-0:1.10.3-1.module_2044+a37cc272.x86_64
+    - golang-docs-0:1.10.3-1.module_2044+a37cc272.noarch
+    - golang-misc-0:1.10.3-1.module_2044+a37cc272.noarch
+    - golang-race-0:1.10.3-1.module_2044+a37cc272.x86_64
+    - golang-shared-0:1.10.3-1.module_2044+a37cc272.x86_64
+    - golang-src-0:1.10.3-1.module_2044+a37cc272.noarch
+    - golang-tests-0:1.10.3-1.module_2044+a37cc272.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: gimp
+  stream: 2.10
+  version: 20180824144949
+  context: 6c81f848
+  arch: x86_64
+  summary: GIMP
+  description: >-
+    A module containing GIMP, the GNU Image Manipulation Program.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv3+ and GPLv3
+    - LGPLv3+
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/gimp.git?#413d972eaa41fbdfdff2a4fc6dfe909c0bee0f74
+      commit: 413d972eaa41fbdfdff2a4fc6dfe909c0bee0f74
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        gimp:
+          ref: 5806be946febc58b68ec28a3af16eab0e9207435
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://www.gimp.org/
+    documentation: https://www.gimp.org/docs/
+    tracker: https://www.gimp.org/bugs/
+  profiles:
+    default:
+      rpms:
+      - gimp
+    devel:
+      rpms:
+      - gimp-devel
+      - gimp-devel-tools
+  api:
+    rpms:
+    - gimp
+    - gimp-devel
+    - gimp-devel-tools
+    - gimp-libs
+  components:
+    rpms:
+      gimp:
+        rationale: The API of this module.
+        repository: git+https://src.fedoraproject.org/rpms/gimp
+        cache: https://src.fedoraproject.org/repo/pkgs/gimp
+        ref: 2.10
+  artifacts:
+    rpms:
+    - gimp-2:2.10.6-2.module_2129+8576126a.x86_64
+    - gimp-devel-2:2.10.6-2.module_2129+8576126a.x86_64
+    - gimp-devel-tools-2:2.10.6-2.module_2129+8576126a.x86_64
+    - gimp-libs-2:2.10.6-2.module_2129+8576126a.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: gcsf
+  stream: master
+  version: 20180804153258
+  context: b33445dc
+  arch: x86_64
+  summary: FUSE file system based on Google Drive
+  description: >
+    GCSF is a virtual filesystem that allows users to mount their
+
+    Google Drive account locally and interact with it as a
+
+    regular disk partition.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/gcsf.git?#bb5cd4eaae70cda43091e1bf45043d38fa155064
+      commit: bb5cd4eaae70cda43091e1bf45043d38fa155064
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        rust-gcsf:
+          ref: 56af97ed27afeccc68bddffac38606da5b8f8ed7
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: []
+  references:
+    community: https://github.com/harababurel/gcsf
+    documentation: https://github.com/harababurel/gcsf/blob/master/README.md
+    tracker: https://github.com/harababurel/gcsf/issues
+  profiles:
+    default:
+      rpms:
+      - gcsf
+  api:
+    rpms:
+    - gcsf
+  components:
+    rpms:
+      rust-gcsf:
+        rationale: Main component.
+        repository: git://pkgs.fedoraproject.org/rpms/rust-gcsf
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/rust-gcsf
+        ref: master
+  artifacts:
+    rpms:
+    - gcsf-0:0.1.17-1.module_1970+c9821572.x86_64
+    - rust-gcsf-devel-0:0.1.17-1.module_1970+c9821572.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: flatpak-runtime
+  stream: f29
+  version: 20180821220306
+  context: 6c81f848
+  arch: x86_64
+  summary: Flatpak Runtime
+  description: >-
+    This module defines two runtimes for Flatpaks, the 'runtime' profile that most
+    Flatpaks in Fedora use, and a smaller 'runtime-base' profile that is intended
+    to be more minimal and (slightly) more API stable. There are also corresponding
+    sdk and sdk-base profiles that are used to build SDKs that applications can be
+    built against with flatpak-builder.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+  xmd:
+    flatpak:
+      runtimes:
+        sdk:
+          id: org.fedoraproject.Sdk
+          sdk: org.fedoraproject.Platform
+        sdk-base:
+          id: org.fedoraproject.BaseSdk
+          sdk: org.fedoraproject.BasePlatform
+        runtime:
+          id: org.fedoraproject.Platform
+          sdk: org.fedoraproject.Sdk
+        runtime-base:
+          id: org.fedoraproject.BasePlatform
+          sdk: org.fedoraproject.BaseSdk
+      branch: f29
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/flatpak-runtime.git?#32b413f59feb051f360b242d065496f330f2ae9a
+      commit: 32b413f59feb051f360b242d065496f330f2ae9a
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        flatpak-runtime-config:
+          ref: eab96c8f9b8f4c96b8e1eddd0fb57bb64025da61
+        flatpak-rpm-macros:
+          ref: e51f66a27ac1c1ef5ae64be5aef3bdcde2124b64
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  profiles:
+    buildroot:
+      rpms:
+      - flatpak-rpm-macros
+      - flatpak-runtime-config
+    runtime:
+      rpms:
+      - ModemManager-glib
+      - SDL2
+      - SDL2_image
+      - SDL2_mixer
+      - SDL2_net
+      - SDL2_ttf
+      - abattis-cantarell-fonts
+      - acl
+      - adwaita-cursor-theme
+      - adwaita-gtk2-theme
+      - adwaita-icon-theme
+      - alsa-lib
+      - aspell
+      - at-spi2-atk
+      - at-spi2-core
+      - atk
+      - attr
+      - audit-libs
+      - avahi-glib
+      - avahi-libs
+      - basesystem
+      - bash
+      - brotli
+      - bzip2
+      - bzip2-libs
+      - ca-certificates
+      - cairo
+      - cairo-gobject
+      - cdparanoia-libs
+      - chkconfig
+      - clutter
+      - clutter-gst3
+      - clutter-gtk
+      - cogl
+      - colord-libs
+      - compat-readline6
+      - coreutils
+      - coreutils-common
+      - cpio
+      - cracklib
+      - crypto-policies
+      - cryptsetup-libs
+      - cups-libs
+      - curl
+      - cyrus-sasl-lib
+      - dbus
+      - dbus-common
+      - dbus-daemon
+      - dbus-glib
+      - dbus-libs
+      - dbus-tools
+      - dbus-x11
+      - dconf
+      - dejavu-fonts-common
+      - dejavu-sans-fonts
+      - dejavu-sans-mono-fonts
+      - dejavu-serif-fonts
+      - desktop-file-utils
+      - device-mapper
+      - device-mapper-libs
+      - elfutils
+      - elfutils-default-yama-scope
+      - elfutils-libelf
+      - elfutils-libs
+      - emacs-filesystem
+      - enchant
+      - eosrei-emojione-fonts
+      - expat
+      - fedora-gpg-keys
+      - fedora-release
+      - fedora-repos
+      - fedora-repos-rawhide
+      - file
+      - file-libs
+      - filesystem
+      - findutils
+      - flac-libs
+      - flatpak-runtime-config
+      - fontconfig
+      - fontpackages-filesystem
+      - freetype
+      - fribidi
+      - gawk
+      - gcr
+      - gdbm
+      - gdbm-libs
+      - gdk-pixbuf2
+      - gdk-pixbuf2-modules
+      - geoclue2
+      - geoclue2-libs
+      - gjs
+      - glib-networking
+      - glib2
+      - glibc
+      - glibc-all-langpacks
+      - glibc-common
+      - glibc-minimal-langpack
+      - gmp
+      - gnome-themes-extra
+      - gnu-free-fonts-common
+      - gnu-free-mono-fonts
+      - gnu-free-sans-fonts
+      - gnu-free-serif-fonts
+      - gnupg
+      - gnupg2
+      - gnupg2-smime
+      - gnutls
+      - gobject-introspection
+      - google-crosextra-caladea-fonts
+      - google-crosextra-carlito-fonts
+      - google-noto-emoji-color-fonts
+      - gpgme
+      - graphite2
+      - grep
+      - gsettings-desktop-schemas
+      - gsm
+      - gssdp
+      - gstreamer1
+      - gstreamer1-plugins-bad-free
+      - gstreamer1-plugins-base
+      - gtk-update-icon-cache
+      - gtk2
+      - gtk2-engines
+      - gtk3
+      - gupnp
+      - gupnp-igd
+      - gzip
+      - harfbuzz
+      - harfbuzz-icu
+      - hicolor-icon-theme
+      - hunspell
+      - hunspell-en-US
+      - hwdata
+      - hyphen
+      - ibus-libs
+      - info
+      - iptables-libs
+      - iso-codes
+      - jasper-libs
+      - jbigkit-libs
+      - json-c
+      - json-glib
+      - keyutils-libs
+      - kmod-libs
+      - krb5-libs
+      - krb5-server
+      - krb5-workstation
+      - lcms2
+      - lcms2-utils
+      - less
+      - libICE
+      - libSM
+      - libX11
+      - libX11-common
+      - libX11-xcb
+      - libXScrnSaver
+      - libXau
+      - libXcomposite
+      - libXcursor
+      - libXdamage
+      - libXdmcp
+      - libXext
+      - libXfixes
+      - libXft
+      - libXi
+      - libXinerama
+      - libXpm
+      - libXrandr
+      - libXrender
+      - libXt
+      - libXtst
+      - libXv
+      - libXxf86vm
+      - libacl
+      - libappstream-glib
+      - libarchive
+      - libargon2
+      - libassuan
+      - libasyncns
+      - libatomic
+      - libattr
+      - libblkid
+      - libcanberra
+      - libcanberra-gtk2
+      - libcanberra-gtk3
+      - libcap
+      - libcap-ng
+      - libcom_err
+      - libcroco
+      - libcurl
+      - libdatrie
+      - libdb
+      - libdrm
+      - libdvdnav
+      - libdvdread
+      - libedit
+      - libepoxy
+      - liberation-fonts-common
+      - liberation-mono-fonts
+      - liberation-sans-fonts
+      - liberation-serif-fonts
+      - libev
+      - libevdev
+      - libexif
+      - libfdisk
+      - libffi
+      - libgcab1
+      - libgcc
+      - libgcrypt
+      - libgfortran
+      - libglvnd
+      - libglvnd-egl
+      - libglvnd-gles
+      - libglvnd-glx
+      - libglvnd-opengl
+      - libgomp
+      - libgpg-error
+      - libgudev
+      - libgusb
+      - libicu
+      - libidn2
+      - libinput
+      - libjpeg-turbo
+      - libkadm5
+      - libksba
+      - libmetalink
+      - libmodman
+      - libmount
+      - libmpc
+      - libmpcdec
+      - libnghttp2
+      - libnice
+      - libnotify
+      - libnsl
+      - libnsl2
+      - libogg
+      - libpcap
+      - libpciaccess
+      - libpkgconf
+      - libpng
+      - libproxy
+      - libpsl
+      - libpwquality
+      - libquadmath
+      - librsvg2
+      - librsvg2-tools
+      - libsamplerate
+      - libseccomp
+      - libsecret
+      - libselinux
+      - libsemanage
+      - libsepol
+      - libsigsegv
+      - libsmartcols
+      - libsndfile
+      - libsoup
+      - libsrtp
+      - libss
+      - libssh
+      - libstdc++
+      - libstemmer
+      - libtasn1
+      - libtdb
+      - libthai
+      - libtheora
+      - libtiff
+      - libtirpc
+      - libtool-ltdl
+      - libunistring
+      - libusb
+      - libusbx
+      - libutempter
+      - libuuid
+      - libvdpau
+      - libverto
+      - libverto-libev
+      - libvisual
+      - libvorbis
+      - libwacom
+      - libwacom-data
+      - libwayland-client
+      - libwayland-cursor
+      - libwayland-egl
+      - libwayland-server
+      - libwebp
+      - libxcb
+      - libxcrypt
+      - libxkbcommon
+      - libxkbcommon-x11
+      - libxml2
+      - libxshmfence
+      - libxslt
+      - llvm-libs
+      - llvm6.0-libs
+      - logrotate
+      - lz4-libs
+      - mesa-dri-drivers
+      - mesa-filesystem
+      - mesa-libEGL
+      - mesa-libGL
+      - mesa-libgbm
+      - mesa-libglapi
+      - mesa-libxatracker
+      - mesa-vulkan-drivers
+      - mlocate
+      - mozjs52
+      - mpfr
+      - mpg123-libs
+      - mtdev
+      - mythes
+      - ncompress
+      - ncurses
+      - ncurses-base
+      - ncurses-compat-libs
+      - ncurses-libs
+      - nettle
+      - npth
+      - nspr
+      - nss
+      - nss-softokn
+      - nss-softokn-freebl
+      - nss-sysinit
+      - nss-tools
+      - nss-util
+      - ocl-icd
+      - openal-soft
+      - openldap
+      - openssl
+      - openssl-libs
+      - opus
+      - orc
+      - p11-kit
+      - p11-kit-trust
+      - pam
+      - pango
+      - pcre
+      - pcre-cpp
+      - pcre2
+      - pcre2-utf16
+      - pcre2-utf32
+      - pinentry
+      - pixman
+      - pkgconf
+      - pkgconf-m4
+      - pkgconf-pkg-config
+      - popt
+      - procps-ng
+      - publicsuffix-list-dafsa
+      - pulseaudio-libs
+      - pulseaudio-libs-glib2
+      - pulseaudio-utils
+      - python-pip-wheel
+      - python-setuptools-wheel
+      - python-unversioned-command
+      - python2
+      - python2-libproxy
+      - python2-libs
+      - python2-libxml2
+      - python2-pip
+      - python2-setuptools
+      - python3
+      - python3-libs
+      - python3-pip
+      - python3-setuptools
+      - qrencode-libs
+      - readline
+      - rest
+      - rpcgen
+      - sed
+      - setup
+      - shadow-utils
+      - shared-mime-info
+      - sound-theme-freedesktop
+      - soundtouch
+      - speex
+      - speexdsp
+      - spirv-tools-libs
+      - sqlite-libs
+      - systemd
+      - systemd-libs
+      - systemd-pam
+      - tar
+      - turbojpeg
+      - tzdata
+      - unzip
+      - util-linux
+      - vte-profile
+      - vte291
+      - vulkan-loader
+      - vulkan-validation-layers
+      - webkit2gtk3
+      - webkit2gtk3-jsc
+      - webrtc-audio-processing
+      - which
+      - woff2
+      - words
+      - xcb-util
+      - xcb-util-cursor
+      - xcb-util-image
+      - xcb-util-keysyms
+      - xcb-util-renderutil
+      - xcb-util-wm
+      - xdg-user-dirs
+      - xdg-utils
+      - xkeyboard-config
+      - xml-common
+      - xz
+      - xz-libs
+      - xz-lzma-compat
+      - yelp
+      - yelp-libs
+      - yelp-xsl
+      - zenity
+      - zip
+      - zlib
+    runtime-base:
+      rpms:
+      - ModemManager-glib
+      - SDL2
+      - SDL2_image
+      - SDL2_mixer
+      - SDL2_net
+      - SDL2_ttf
+      - acl
+      - adwaita-cursor-theme
+      - adwaita-icon-theme
+      - alsa-lib
+      - aspell
+      - at-spi2-atk
+      - at-spi2-core
+      - atk
+      - attr
+      - audit-libs
+      - avahi-glib
+      - avahi-libs
+      - basesystem
+      - bash
+      - brotli
+      - bzip2
+      - bzip2-libs
+      - ca-certificates
+      - cairo
+      - cairo-gobject
+      - cdparanoia-libs
+      - chkconfig
+      - colord-libs
+      - compat-readline6
+      - coreutils
+      - coreutils-common
+      - cpio
+      - cracklib
+      - crypto-policies
+      - cryptsetup-libs
+      - cups-libs
+      - curl
+      - cyrus-sasl-lib
+      - dbus
+      - dbus-common
+      - dbus-daemon
+      - dbus-libs
+      - dbus-tools
+      - dbus-x11
+      - dconf
+      - dejavu-fonts-common
+      - dejavu-sans-fonts
+      - dejavu-sans-mono-fonts
+      - dejavu-serif-fonts
+      - desktop-file-utils
+      - device-mapper
+      - device-mapper-libs
+      - elfutils
+      - elfutils-default-yama-scope
+      - elfutils-libelf
+      - elfutils-libs
+      - emacs-filesystem
+      - eosrei-emojione-fonts
+      - expat
+      - fedora-gpg-keys
+      - fedora-release
+      - fedora-repos
+      - fedora-repos-rawhide
+      - file
+      - file-libs
+      - filesystem
+      - findutils
+      - flac-libs
+      - flatpak-runtime-config
+      - fontconfig
+      - fontpackages-filesystem
+      - freetype
+      - fribidi
+      - gawk
+      - gdbm
+      - gdbm-libs
+      - gdk-pixbuf2
+      - gdk-pixbuf2-modules
+      - geoclue2
+      - geoclue2-libs
+      - glib-networking
+      - glib2
+      - glibc
+      - glibc-all-langpacks
+      - glibc-common
+      - glibc-minimal-langpack
+      - gmp
+      - gnu-free-fonts-common
+      - gnu-free-mono-fonts
+      - gnu-free-sans-fonts
+      - gnu-free-serif-fonts
+      - gnupg
+      - gnupg2
+      - gnupg2-smime
+      - gnutls
+      - gobject-introspection
+      - google-crosextra-caladea-fonts
+      - google-crosextra-carlito-fonts
+      - gpgme
+      - graphite2
+      - grep
+      - gsettings-desktop-schemas
+      - gsm
+      - gssdp
+      - gstreamer1
+      - gstreamer1-plugins-bad-free
+      - gstreamer1-plugins-base
+      - gtk-update-icon-cache
+      - gtk3
+      - gupnp
+      - gupnp-igd
+      - gzip
+      - harfbuzz
+      - harfbuzz-icu
+      - hicolor-icon-theme
+      - hunspell
+      - hunspell-en-US
+      - hwdata
+      - hyphen
+      - ibus-libs
+      - info
+      - iptables-libs
+      - iso-codes
+      - jasper-libs
+      - jbigkit-libs
+      - json-c
+      - json-glib
+      - keyutils-libs
+      - kmod-libs
+      - krb5-libs
+      - krb5-server
+      - krb5-workstation
+      - lcms2
+      - lcms2-utils
+      - less
+      - libICE
+      - libSM
+      - libX11
+      - libX11-common
+      - libX11-xcb
+      - libXScrnSaver
+      - libXau
+      - libXcomposite
+      - libXcursor
+      - libXdamage
+      - libXdmcp
+      - libXext
+      - libXfixes
+      - libXft
+      - libXi
+      - libXinerama
+      - libXpm
+      - libXrandr
+      - libXrender
+      - libXt
+      - libXtst
+      - libXv
+      - libXxf86vm
+      - libacl
+      - libappstream-glib
+      - libarchive
+      - libargon2
+      - libassuan
+      - libasyncns
+      - libatomic
+      - libattr
+      - libblkid
+      - libcap
+      - libcap-ng
+      - libcom_err
+      - libcroco
+      - libcurl
+      - libdatrie
+      - libdb
+      - libdrm
+      - libdvdnav
+      - libdvdread
+      - libedit
+      - libepoxy
+      - liberation-fonts-common
+      - liberation-mono-fonts
+      - liberation-sans-fonts
+      - liberation-serif-fonts
+      - libev
+      - libexif
+      - libfdisk
+      - libffi
+      - libgcab1
+      - libgcc
+      - libgcrypt
+      - libgfortran
+      - libglvnd
+      - libglvnd-egl
+      - libglvnd-gles
+      - libglvnd-glx
+      - libglvnd-opengl
+      - libgomp
+      - libgpg-error
+      - libgudev
+      - libgusb
+      - libicu
+      - libidn2
+      - libjpeg-turbo
+      - libkadm5
+      - libksba
+      - libmetalink
+      - libmodman
+      - libmount
+      - libmpc
+      - libmpcdec
+      - libnghttp2
+      - libnice
+      - libnotify
+      - libnsl
+      - libnsl2
+      - libogg
+      - libpcap
+      - libpciaccess
+      - libpkgconf
+      - libpng
+      - libproxy
+      - libpsl
+      - libpwquality
+      - libquadmath
+      - librsvg2
+      - librsvg2-tools
+      - libsamplerate
+      - libseccomp
+      - libsecret
+      - libselinux
+      - libsemanage
+      - libsepol
+      - libsigsegv
+      - libsmartcols
+      - libsndfile
+      - libsoup
+      - libsrtp
+      - libss
+      - libssh
+      - libstdc++
+      - libstemmer
+      - libtasn1
+      - libthai
+      - libtheora
+      - libtiff
+      - libtirpc
+      - libtool-ltdl
+      - libunistring
+      - libusb
+      - libusbx
+      - libutempter
+      - libuuid
+      - libvdpau
+      - libverto
+      - libverto-libev
+      - libvisual
+      - libvorbis
+      - libwayland-client
+      - libwayland-cursor
+      - libwayland-egl
+      - libwayland-server
+      - libwebp
+      - libxcb
+      - libxcrypt
+      - libxkbcommon
+      - libxkbcommon-x11
+      - libxml2
+      - libxshmfence
+      - libxslt
+      - llvm-libs
+      - llvm6.0-libs
+      - logrotate
+      - lz4-libs
+      - mesa-libEGL
+      - mesa-libGL
+      - mesa-libgbm
+      - mesa-libglapi
+      - mesa-libxatracker
+      - mesa-vulkan-drivers
+      - mlocate
+      - mpfr
+      - mpg123-libs
+      - mythes
+      - ncompress
+      - ncurses
+      - ncurses-base
+      - ncurses-compat-libs
+      - ncurses-libs
+      - nettle
+      - npth
+      - nspr
+      - nss
+      - nss-softokn
+      - nss-softokn-freebl
+      - nss-sysinit
+      - nss-tools
+      - nss-util
+      - ocl-icd
+      - openal-soft
+      - openldap
+      - openssl
+      - openssl-libs
+      - opus
+      - orc
+      - p11-kit
+      - p11-kit-trust
+      - pam
+      - pango
+      - pcre
+      - pcre-cpp
+      - pcre2
+      - pcre2-utf16
+      - pcre2-utf32
+      - pinentry
+      - pixman
+      - pkgconf
+      - pkgconf-m4
+      - pkgconf-pkg-config
+      - popt
+      - procps-ng
+      - publicsuffix-list-dafsa
+      - pulseaudio-libs
+      - pulseaudio-libs-glib2
+      - pulseaudio-utils
+      - python-unversioned-command
+      - python2
+      - python2-libproxy
+      - python2-libs
+      - python2-libxml2
+      - python2-pip
+      - python2-setuptools
+      - python3
+      - python3-libs
+      - python3-pip
+      - python3-setuptools
+      - qrencode-libs
+      - readline
+      - rest
+      - rpcgen
+      - sed
+      - setup
+      - shadow-utils
+      - shared-mime-info
+      - soundtouch
+      - speex
+      - speexdsp
+      - spirv-tools-libs
+      - sqlite-libs
+      - systemd
+      - systemd-libs
+      - systemd-pam
+      - tar
+      - turbojpeg
+      - tzdata
+      - unzip
+      - util-linux
+      - vulkan-loader
+      - vulkan-validation-layers
+      - webrtc-audio-processing
+      - which
+      - words
+      - xcb-util
+      - xcb-util-cursor
+      - xcb-util-image
+      - xcb-util-keysyms
+      - xcb-util-renderutil
+      - xcb-util-wm
+      - xdg-user-dirs
+      - xdg-utils
+      - xkeyboard-config
+      - xml-common
+      - xz
+      - xz-libs
+      - xz-lzma-compat
+      - zenity
+      - zip
+      - zlib
+    sdk:
+      rpms:
+      - ModemManager-glib
+      - SDL2
+      - SDL2-devel
+      - SDL2_image
+      - SDL2_image-devel
+      - SDL2_mixer
+      - SDL2_mixer-devel
+      - SDL2_net
+      - SDL2_net-devel
+      - SDL2_ttf
+      - SDL2_ttf-devel
+      - abattis-cantarell-fonts
+      - acl
+      - adwaita-cursor-theme
+      - adwaita-gtk2-theme
+      - adwaita-icon-theme
+      - adwaita-icon-theme-devel
+      - alsa-lib
+      - alsa-lib-devel
+      - annobin
+      - aspell
+      - aspell-devel
+      - at-spi2-atk
+      - at-spi2-atk-devel
+      - at-spi2-core
+      - at-spi2-core-devel
+      - atk
+      - atk-devel
+      - attr
+      - audit-libs
+      - autoconf
+      - autoconf-archive
+      - autogen-libopts
+      - automake
+      - avahi-glib
+      - avahi-libs
+      - basesystem
+      - bash
+      - bash-completion
+      - bc
+      - binutils
+      - bison
+      - boost-regex
+      - brotli
+      - brotli-devel
+      - byacc
+      - bzip2
+      - bzip2-devel
+      - bzip2-libs
+      - ca-certificates
+      - cairo
+      - cairo-devel
+      - cairo-gobject
+      - cairo-gobject-devel
+      - cairo-tools
+      - ccache
+      - cdparanoia-libs
+      - check
+      - check-devel
+      - chkconfig
+      - chrpath
+      - clang
+      - clang-analyzer
+      - clang-devel
+      - clang-libs
+      - clang-tools-extra
+      - clutter
+      - clutter-devel
+      - clutter-gst3
+      - clutter-gst3-devel
+      - clutter-gtk
+      - clutter-gtk-devel
+      - cmake
+      - cmake-data
+      - cmake-filesystem
+      - cmake-rpm-macros
+      - cogl
+      - cogl-devel
+      - colord-libs
+      - compat-readline6
+      - coreutils
+      - coreutils-common
+      - cpio
+      - cpp
+      - cracklib
+      - cracklib-devel
+      - crypto-policies
+      - cryptsetup-libs
+      - ctags
+      - cups-devel
+      - cups-libs
+      - curl
+      - cvs
+      - cvsps
+      - cyrus-sasl
+      - cyrus-sasl-devel
+      - cyrus-sasl-lib
+      - dbus
+      - dbus-common
+      - dbus-daemon
+      - dbus-devel
+      - dbus-glib
+      - dbus-glib-devel
+      - dbus-libs
+      - dbus-tools
+      - dbus-x11
+      - dconf
+      - dconf-devel
+      - dejavu-fonts-common
+      - dejavu-sans-fonts
+      - dejavu-sans-mono-fonts
+      - dejavu-serif-fonts
+      - desktop-file-utils
+      - device-mapper
+      - device-mapper-libs
+      - diffutils
+      - docbook-dtds
+      - docbook-style-dsssl
+      - docbook-style-xsl
+      - docbook-utils
+      - dwz
+      - e2fsprogs
+      - e2fsprogs-devel
+      - e2fsprogs-libs
+      - efi-srpm-macros
+      - elfutils
+      - elfutils-default-yama-scope
+      - elfutils-devel
+      - elfutils-libelf
+      - elfutils-libelf-devel
+      - elfutils-libs
+      - elinks
+      - emacs-filesystem
+      - enchant
+      - enchant-devel
+      - eosrei-emojione-fonts
+      - expat
+      - expat-devel
+      - fedora-gpg-keys
+      - fedora-release
+      - fedora-repos
+      - fedora-repos-rawhide
+      - file
+      - file-libs
+      - filesystem
+      - findutils
+      - fipscheck
+      - fipscheck-lib
+      - flac
+      - flac-devel
+      - flac-libs
+      - flatpak-runtime-config
+      - flex
+      - fontconfig
+      - fontconfig-devel
+      - fontpackages-filesystem
+      - fpc-srpm-macros
+      - freetype
+      - freetype-devel
+      - fribidi
+      - fribidi-devel
+      - fuse-libs
+      - gawk
+      - gc
+      - gcc
+      - gcc-c++
+      - gcr
+      - gcr-devel
+      - gdb
+      - gdb-headless
+      - gdbm
+      - gdbm-devel
+      - gdbm-libs
+      - gdk-pixbuf2
+      - gdk-pixbuf2-devel
+      - gdk-pixbuf2-modules
+      - geoclue2
+      - geoclue2-devel
+      - geoclue2-libs
+      - gettext
+      - gettext-common-devel
+      - gettext-devel
+      - gettext-libs
+      - ghc-srpm-macros
+      - giflib
+      - giflib-devel
+      - git
+      - git-clang-format
+      - git-core
+      - git-core-doc
+      - git-cvs
+      - gjs
+      - gjs-devel
+      - glib-networking
+      - glib2
+      - glib2-devel
+      - glibc
+      - glibc-all-langpacks
+      - glibc-common
+      - glibc-devel
+      - glibc-headers
+      - glibc-minimal-langpack
+      - gmp
+      - gmp-c++
+      - gmp-devel
+      - gnat-srpm-macros
+      - gnome-common
+      - gnome-themes-extra
+      - gnu-free-fonts-common
+      - gnu-free-mono-fonts
+      - gnu-free-sans-fonts
+      - gnu-free-serif-fonts
+      - gnupg
+      - gnupg2
+      - gnupg2-smime
+      - gnutls
+      - gnutls-c++
+      - gnutls-dane
+      - gnutls-devel
+      - gnutls-utils
+      - go-srpm-macros
+      - gobject-introspection
+      - gobject-introspection-devel
+      - google-crosextra-caladea-fonts
+      - google-crosextra-carlito-fonts
+      - google-noto-emoji-color-fonts
+      - gperf
+      - gpgme
+      - gpgme-devel
+      - gpm-libs
+      - graphite2
+      - graphite2-devel
+      - grep
+      - groff
+      - groff-base
+      - groff-perl
+      - gsettings-desktop-schemas
+      - gsettings-desktop-schemas-devel
+      - gsm
+      - gssdp
+      - gstreamer1
+      - gstreamer1-devel
+      - gstreamer1-plugins-bad-free
+      - gstreamer1-plugins-bad-free-devel
+      - gstreamer1-plugins-base
+      - gstreamer1-plugins-base-devel
+      - gtk-doc
+      - gtk-update-icon-cache
+      - gtk2
+      - gtk2-devel
+      - gtk2-engines
+      - gtk2-engines-devel
+      - gtk3
+      - gtk3-devel
+      - guile
+      - gupnp
+      - gupnp-igd
+      - gvfs-client
+      - gvfs-devel
+      - gzip
+      - harfbuzz
+      - harfbuzz-devel
+      - harfbuzz-icu
+      - hicolor-icon-theme
+      - hunspell
+      - hunspell-devel
+      - hunspell-en-US
+      - hwdata
+      - hyphen
+      - hyphen-devel
+      - ibus
+      - ibus-devel
+      - ibus-gtk2
+      - ibus-gtk3
+      - ibus-libs
+      - ibus-setup
+      - icu
+      - info
+      - intltool
+      - iptables-libs
+      - isl
+      - iso-codes
+      - iso-codes-devel
+      - itstool
+      - jasper-libs
+      - jbigkit-libs
+      - jq
+      - jq-devel
+      - json-c
+      - json-c-devel
+      - json-glib
+      - json-glib-devel
+      - jsoncpp
+      - kernel-headers
+      - keyutils-libs
+      - keyutils-libs-devel
+      - kmod-libs
+      - krb5-devel
+      - krb5-libs
+      - krb5-server
+      - krb5-workstation
+      - lcms2
+      - lcms2-devel
+      - lcms2-utils
+      - less
+      - libICE
+      - libICE-devel
+      - libSM
+      - libSM-devel
+      - libX11
+      - libX11-common
+      - libX11-devel
+      - libX11-xcb
+      - libXScrnSaver
+      - libXScrnSaver-devel
+      - libXau
+      - libXau-devel
+      - libXaw
+      - libXcomposite
+      - libXcomposite-devel
+      - libXcursor
+      - libXcursor-devel
+      - libXdamage
+      - libXdamage-devel
+      - libXdmcp
+      - libXdmcp-devel
+      - libXext
+      - libXext-devel
+      - libXfixes
+      - libXfixes-devel
+      - libXft
+      - libXft-devel
+      - libXi
+      - libXi-devel
+      - libXinerama
+      - libXinerama-devel
+      - libXmu
+      - libXpm
+      - libXpm-devel
+      - libXrandr
+      - libXrandr-devel
+      - libXrender
+      - libXrender-devel
+      - libXt
+      - libXt-devel
+      - libXtst
+      - libXtst-devel
+      - libXv
+      - libXv-devel
+      - libXxf86misc
+      - libXxf86vm
+      - libXxf86vm-devel
+      - libacl
+      - libacl-devel
+      - libappstream-glib
+      - libappstream-glib-builder
+      - libappstream-glib-builder-devel
+      - libappstream-glib-devel
+      - libarchive
+      - libarchive-devel
+      - libargon2
+      - libassuan
+      - libassuan-devel
+      - libasyncns
+      - libatomic
+      - libatomic_ops
+      - libatomic_ops-devel
+      - libattr
+      - libattr-devel
+      - libbabeltrace
+      - libblkid
+      - libblkid-devel
+      - libcanberra
+      - libcanberra-devel
+      - libcanberra-gtk2
+      - libcanberra-gtk3
+      - libcap
+      - libcap-devel
+      - libcap-ng
+      - libcom_err
+      - libcom_err-devel
+      - libcroco
+      - libcroco-devel
+      - libcurl
+      - libcurl-devel
+      - libdatrie
+      - libdatrie-devel
+      - libdb
+      - libdb-cxx
+      - libdb-cxx-devel
+      - libdb-devel
+      - libdb-utils
+      - libdrm
+      - libdrm-devel
+      - libdvdnav
+      - libdvdread
+      - libedit
+      - libedit-devel
+      - libepoxy
+      - libepoxy-devel
+      - liberation-fonts-common
+      - liberation-mono-fonts
+      - liberation-sans-fonts
+      - liberation-serif-fonts
+      - libev
+      - libevdev
+      - libevent
+      - libexif
+      - libexif-devel
+      - libfdisk
+      - libfdisk-devel
+      - libffi
+      - libffi-devel
+      - libgcab1
+      - libgcab1-devel
+      - libgcc
+      - libgcrypt
+      - libgcrypt-devel
+      - libgfortran
+      - libglvnd
+      - libglvnd-core-devel
+      - libglvnd-devel
+      - libglvnd-egl
+      - libglvnd-gles
+      - libglvnd-glx
+      - libglvnd-opengl
+      - libgomp
+      - libgpg-error
+      - libgpg-error-devel
+      - libgudev
+      - libgusb
+      - libicu
+      - libicu-devel
+      - libidn
+      - libidn-devel
+      - libidn2
+      - libinput
+      - libinput-devel
+      - libipt
+      - libjpeg-turbo
+      - libjpeg-turbo-devel
+      - libkadm5
+      - libksba
+      - libmcpp
+      - libmetalink
+      - libmodman
+      - libmount
+      - libmount-devel
+      - libmpc
+      - libmpc-devel
+      - libmpcdec
+      - libnghttp2
+      - libnice
+      - libnotify
+      - libnotify-devel
+      - libnsl
+      - libnsl2
+      - libnsl2-devel
+      - libogg
+      - libogg-devel
+      - libpcap
+      - libpciaccess
+      - libpciaccess-devel
+      - libpipeline
+      - libpkgconf
+      - libpng
+      - libpng-devel
+      - libproxy
+      - libproxy-devel
+      - libpsl
+      - libpwquality
+      - libquadmath
+      - librsvg2
+      - librsvg2-devel
+      - librsvg2-tools
+      - libsamplerate
+      - libsamplerate-devel
+      - libseccomp
+      - libseccomp-devel
+      - libsecret
+      - libsecret-devel
+      - libselinux
+      - libselinux-devel
+      - libsemanage
+      - libsepol
+      - libsepol-devel
+      - libsigsegv
+      - libsmartcols
+      - libsmartcols-devel
+      - libsndfile
+      - libsndfile-devel
+      - libsoup
+      - libsoup-devel
+      - libsrtp
+      - libss
+      - libss-devel
+      - libssh
+      - libstdc++
+      - libstdc++-devel
+      - libstemmer
+      - libtasn1
+      - libtasn1-devel
+      - libtasn1-tools
+      - libtdb
+      - libthai
+      - libthai-devel
+      - libtheora
+      - libtheora-devel
+      - libtiff
+      - libtiff-devel
+      - libtirpc
+      - libtirpc-devel
+      - libtool
+      - libtool-ltdl
+      - libtool-ltdl-devel
+      - libunistring
+      - libusb
+      - libusbx
+      - libutempter
+      - libuuid
+      - libuuid-devel
+      - libuv
+      - libva
+      - libva-devel
+      - libva-utils
+      - libvdpau
+      - libvdpau-devel
+      - libvdpau-trace
+      - libverto
+      - libverto-devel
+      - libverto-libev
+      - libvisual
+      - libvorbis
+      - libvorbis-devel
+      - libvpx
+      - libvpx-devel
+      - libwacom
+      - libwacom-data
+      - libwayland-client
+      - libwayland-cursor
+      - libwayland-egl
+      - libwayland-server
+      - libwebp
+      - libwebp-devel
+      - libxcb
+      - libxcb-devel
+      - libxcrypt
+      - libxcrypt-devel
+      - libxkbcommon
+      - libxkbcommon-devel
+      - libxkbcommon-x11
+      - libxkbcommon-x11-devel
+      - libxkbfile
+      - libxml2
+      - libxml2-devel
+      - libxshmfence
+      - libxshmfence-devel
+      - libxslt
+      - libxslt-devel
+      - libyaml
+      - libyaml-devel
+      - libzstd
+      - llvm
+      - llvm-devel
+      - llvm-libs
+      - llvm6.0-libs
+      - logrotate
+      - lua-libs
+      - lz4-libs
+      - m4
+      - make
+      - mallard-rng
+      - man-db
+      - man2html-core
+      - mcpp
+      - mercurial
+      - mesa-dri-drivers
+      - mesa-filesystem
+      - mesa-libEGL
+      - mesa-libEGL-devel
+      - mesa-libGL
+      - mesa-libGL-devel
+      - mesa-libGLES
+      - mesa-libGLES-devel
+      - mesa-libgbm
+      - mesa-libgbm-devel
+      - mesa-libglapi
+      - mesa-libxatracker
+      - mesa-libxatracker-devel
+      - mesa-vulkan-devel
+      - mesa-vulkan-drivers
+      - meson
+      - mlocate
+      - mozjs52
+      - mozjs52-devel
+      - mpfr
+      - mpfr-devel
+      - mpg123-devel
+      - mpg123-libs
+      - mtdev
+      - mythes
+      - mythes-devel
+      - nasm
+      - ncompress
+      - ncurses
+      - ncurses-base
+      - ncurses-c++-libs
+      - ncurses-compat-libs
+      - ncurses-devel
+      - ncurses-libs
+      - nettle
+      - nettle-devel
+      - nim-srpm-macros
+      - ninja-build
+      - npth
+      - nspr
+      - nspr-devel
+      - nss
+      - nss-devel
+      - nss-pkcs11-devel
+      - nss-softokn
+      - nss-softokn-devel
+      - nss-softokn-freebl
+      - nss-softokn-freebl-devel
+      - nss-sysinit
+      - nss-tools
+      - nss-util
+      - nss-util-devel
+      - nss_db
+      - nss_hesiod
+      - nss_nis
+      - numactl-libs
+      - ocaml-srpm-macros
+      - ocl-icd
+      - ocl-icd-devel
+      - oniguruma
+      - openal-soft
+      - openal-soft-devel
+      - openblas-srpm-macros
+      - opencl-headers
+      - openjade
+      - openjpeg2
+      - openldap
+      - opensp
+      - openssh
+      - openssh-clients
+      - openssl
+      - openssl-devel
+      - openssl-libs
+      - opus
+      - opus-devel
+      - orc
+      - orc-compiler
+      - orc-devel
+      - p11-kit
+      - p11-kit-devel
+      - p11-kit-trust
+      - pam
+      - pam-devel
+      - pango
+      - pango-devel
+      - patch
+      - pcre
+      - pcre-cpp
+      - pcre-devel
+      - pcre-utf16
+      - pcre-utf32
+      - pcre2
+      - pcre2-devel
+      - pcre2-utf16
+      - pcre2-utf32
+      - perf
+      - perl-Algorithm-Diff
+      - perl-Archive-Tar
+      - perl-Archive-Zip
+      - perl-CPAN
+      - perl-CPAN-Meta
+      - perl-CPAN-Meta-Requirements
+      - perl-CPAN-Meta-YAML
+      - perl-Carp
+      - perl-Compress-Bzip2
+      - perl-Compress-Raw-Bzip2
+      - perl-Compress-Raw-Zlib
+      - perl-DBD-SQLite
+      - perl-DBI
+      - perl-Data-Dumper
+      - perl-Data-OptList
+      - perl-Data-Section
+      - perl-Devel-Size
+      - perl-Digest
+      - perl-Digest-MD5
+      - perl-Digest-SHA
+      - perl-Encode
+      - perl-Encode-devel
+      - perl-Errno
+      - perl-Error
+      - perl-Exporter
+      - perl-ExtUtils-CBuilder
+      - perl-ExtUtils-Command
+      - perl-ExtUtils-Install
+      - perl-ExtUtils-MM-Utils
+      - perl-ExtUtils-MakeMaker
+      - perl-ExtUtils-Manifest
+      - perl-ExtUtils-ParseXS
+      - perl-File-HomeDir
+      - perl-File-Path
+      - perl-File-Temp
+      - perl-File-Which
+      - perl-Filter
+      - perl-Getopt-Long
+      - perl-Git
+      - perl-HTTP-Tiny
+      - perl-IO
+      - perl-IO-Compress
+      - perl-IO-Socket-IP
+      - perl-IO-Zlib
+      - perl-IPC-Cmd
+      - perl-JSON-PP
+      - perl-Locale-Maketext
+      - perl-Locale-Maketext-Simple
+      - perl-MIME-Base64
+      - perl-MRO-Compat
+      - perl-Math-BigInt
+      - perl-Math-Complex
+      - perl-Module-Build
+      - perl-Module-CoreList
+      - perl-Module-CoreList-tools
+      - perl-Module-Load
+      - perl-Module-Load-Conditional
+      - perl-Module-Metadata
+      - perl-Net-Ping
+      - perl-Package-Generator
+      - perl-Params-Check
+      - perl-Params-Util
+      - perl-PathTools
+      - perl-Perl-OSType
+      - perl-Pod-Checker
+      - perl-Pod-Escapes
+      - perl-Pod-Html
+      - perl-Pod-Parser
+      - perl-Pod-Perldoc
+      - perl-Pod-Simple
+      - perl-Pod-Usage
+      - perl-SGMLSpm
+      - perl-Scalar-List-Utils
+      - perl-Socket
+      - perl-Software-License
+      - perl-Storable
+      - perl-Sub-Exporter
+      - perl-Sub-Install
+      - perl-Term-ANSIColor
+      - perl-Term-Cap
+      - perl-TermReadKey
+      - perl-Test-Harness
+      - perl-Text-Diff
+      - perl-Text-Glob
+      - perl-Text-ParseWords
+      - perl-Text-Tabs+Wrap
+      - perl-Text-Template
+      - perl-Text-Unidecode
+      - perl-Thread-Queue
+      - perl-Time-HiRes
+      - perl-Time-Local
+      - perl-URI
+      - perl-Unicode-EastAsianWidth
+      - perl-Unicode-Normalize
+      - perl-XML-Parser
+      - perl-XML-XPath
+      - perl-constant
+      - perl-devel
+      - perl-encoding
+      - perl-inc-latest
+      - perl-interpreter
+      - perl-libintl-perl
+      - perl-libnet
+      - perl-libnetcfg
+      - perl-libs
+      - perl-local-lib
+      - perl-macros
+      - perl-open
+      - perl-parent
+      - perl-podlators
+      - perl-srpm-macros
+      - perl-threads
+      - perl-threads-shared
+      - perl-utils
+      - perl-version
+      - pinentry
+      - pixman
+      - pixman-devel
+      - pkgconf
+      - pkgconf-m4
+      - pkgconf-pkg-config
+      - poppler
+      - poppler-data
+      - popt
+      - popt-devel
+      - procps-ng
+      - publicsuffix-list-dafsa
+      - pulseaudio-libs
+      - pulseaudio-libs-devel
+      - pulseaudio-libs-glib2
+      - pulseaudio-utils
+      - pygobject3-devel
+      - python-rpm-macros
+      - python-srpm-macros
+      - python-unversioned-command
+      - python2
+      - python2-cairo
+      - python2-devel
+      - python2-gobject
+      - python2-gobject-base
+      - python2-libproxy
+      - python2-libs
+      - python2-libxml2
+      - python2-mako
+      - python2-markupsafe
+      - python2-pip
+      - python2-rpm-macros
+      - python2-setuptools
+      - python2-xpyb
+      - python3
+      - python3-cairo
+      - python3-cairo-devel
+      - python3-devel
+      - python3-gobject
+      - python3-gobject-base
+      - python3-libs
+      - python3-libxml2
+      - python3-mako
+      - python3-markupsafe
+      - python3-pip
+      - python3-pyparsing
+      - python3-rpm-generators
+      - python3-rpm-macros
+      - python3-setuptools
+      - python3-six
+      - python36
+      - qrencode-libs
+      - qt5-srpm-macros
+      - readline
+      - readline-devel
+      - redhat-rpm-config
+      - rest
+      - rhash
+      - rpcgen
+      - rpcsvc-proto-devel
+      - rpm
+      - rpm-libs
+      - rpm-plugin-selinux
+      - ruby
+      - ruby-irb
+      - ruby-libs
+      - rubygem-io-console
+      - rubygem-json
+      - rubygem-openssl
+      - rubygem-psych
+      - rubygem-rake
+      - rubygem-rdoc
+      - rubygems
+      - rubypick
+      - rust-srpm-macros
+      - sed
+      - setup
+      - sgml-common
+      - shadow-utils
+      - shared-mime-info
+      - slang
+      - slang-slsh
+      - sound-theme-freedesktop
+      - soundtouch
+      - source-highlight
+      - speex
+      - speex-devel
+      - speexdsp
+      - speexdsp-devel
+      - spirv-tools-libs
+      - sqlite
+      - sqlite-devel
+      - sqlite-libs
+      - strace
+      - subunit
+      - subunit-devel
+      - systemd
+      - systemd-devel
+      - systemd-libs
+      - systemd-pam
+      - systemtap-sdt-devel
+      - tar
+      - tcl
+      - tcl-devel
+      - texinfo
+      - texinfo-tex
+      - texlive-amsfonts
+      - texlive-base
+      - texlive-bibtex
+      - texlive-cm
+      - texlive-collection-basic
+      - texlive-dvipdfmx
+      - texlive-dvips
+      - texlive-enctex
+      - texlive-epsf
+      - texlive-etex
+      - texlive-etex-pkg
+      - texlive-glyphlist
+      - texlive-graphics-def
+      - texlive-gsftopk
+      - texlive-hyph-utf8
+      - texlive-hyphen-base
+      - texlive-ifluatex
+      - texlive-ifxetex
+      - texlive-knuth-lib
+      - texlive-knuth-local
+      - texlive-kpathsea
+      - texlive-latex-fonts
+      - texlive-lib
+      - texlive-lua-alt-getopt
+      - texlive-luatex
+      - texlive-makeindex
+      - texlive-metafont
+      - texlive-mflogo
+      - texlive-mfware
+      - texlive-pdftex
+      - texlive-plain
+      - texlive-tetex
+      - texlive-tex
+      - texlive-tex-ini-files
+      - texlive-texconfig
+      - texlive-texlive-common-doc
+      - texlive-texlive-docindex
+      - texlive-texlive-en
+      - texlive-texlive-msg-translations
+      - texlive-texlive-scripts
+      - texlive-texlive.infra
+      - texlive-unicode-data
+      - texlive-updmap-map
+      - texlive-xdvi
+      - tk
+      - turbojpeg
+      - turbojpeg-devel
+      - tzdata
+      - unbound-libs
+      - unzip
+      - util-linux
+      - vala
+      - vala-compat
+      - vala-compat-tools
+      - valgrind
+      - valgrind-devel
+      - valgrind-tools-devel
+      - vim-filesystem
+      - vim-minimal
+      - vte-profile
+      - vte291
+      - vte291-devel
+      - vulkan-headers
+      - vulkan-loader
+      - vulkan-loader-devel
+      - vulkan-validation-layers
+      - vulkan-validation-layers-devel
+      - wayland-devel
+      - wayland-protocols-devel
+      - webkit2gtk3
+      - webkit2gtk3-devel
+      - webkit2gtk3-jsc
+      - webkit2gtk3-jsc-devel
+      - webrtc-audio-processing
+      - which
+      - woff2
+      - woff2-devel
+      - words
+      - xcb-proto
+      - xcb-util
+      - xcb-util-cursor
+      - xcb-util-cursor-devel
+      - xcb-util-devel
+      - xcb-util-image
+      - xcb-util-image-devel
+      - xcb-util-keysyms
+      - xcb-util-keysyms-devel
+      - xcb-util-renderutil
+      - xcb-util-renderutil-devel
+      - xcb-util-wm
+      - xcb-util-wm-devel
+      - xdg-user-dirs
+      - xdg-utils
+      - xkeyboard-config
+      - xkeyboard-config-devel
+      - xml-common
+      - xorg-x11-proto-devel
+      - xorg-x11-server-utils
+      - xorg-x11-util-macros
+      - xorg-x11-xauth
+      - xorg-x11-xinit
+      - xorg-x11-xkb-utils
+      - xorg-x11-xtrans-devel
+      - xz
+      - xz-devel
+      - xz-libs
+      - xz-lzma-compat
+      - yasm
+      - yelp
+      - yelp-devel
+      - yelp-libs
+      - yelp-tools
+      - yelp-xsl
+      - yelp-xsl-devel
+      - zenity
+      - zip
+      - zlib
+      - zlib-devel
+      - zziplib
+    sdk-base:
+      rpms:
+      - ModemManager-glib
+      - SDL2
+      - SDL2-devel
+      - SDL2_image
+      - SDL2_image-devel
+      - SDL2_mixer
+      - SDL2_mixer-devel
+      - SDL2_net
+      - SDL2_net-devel
+      - SDL2_ttf
+      - SDL2_ttf-devel
+      - acl
+      - adwaita-cursor-theme
+      - adwaita-icon-theme
+      - alsa-lib
+      - alsa-lib-devel
+      - annobin
+      - aspell
+      - aspell-devel
+      - at-spi2-atk
+      - at-spi2-atk-devel
+      - at-spi2-core
+      - at-spi2-core-devel
+      - atk
+      - atk-devel
+      - attr
+      - audit-libs
+      - autoconf
+      - autogen-libopts
+      - automake
+      - avahi-glib
+      - avahi-libs
+      - basesystem
+      - bash
+      - bash-completion
+      - bc
+      - binutils
+      - bison
+      - boost-regex
+      - brotli
+      - byacc
+      - bzip2
+      - bzip2-devel
+      - bzip2-libs
+      - ca-certificates
+      - cairo
+      - cairo-devel
+      - cairo-gobject
+      - cairo-gobject-devel
+      - cairo-tools
+      - ccache
+      - cdparanoia-libs
+      - check
+      - check-devel
+      - chkconfig
+      - chrpath
+      - clang
+      - clang-analyzer
+      - clang-devel
+      - clang-libs
+      - clang-tools-extra
+      - cmake
+      - cmake-data
+      - cmake-filesystem
+      - cmake-rpm-macros
+      - colord-libs
+      - compat-readline6
+      - coreutils
+      - coreutils-common
+      - cpio
+      - cpp
+      - cracklib
+      - cracklib-devel
+      - crypto-policies
+      - cryptsetup-libs
+      - ctags
+      - cups-devel
+      - cups-libs
+      - curl
+      - cvs
+      - cvsps
+      - cyrus-sasl
+      - cyrus-sasl-devel
+      - cyrus-sasl-lib
+      - dbus
+      - dbus-common
+      - dbus-daemon
+      - dbus-devel
+      - dbus-libs
+      - dbus-tools
+      - dbus-x11
+      - dconf
+      - dconf-devel
+      - dejavu-fonts-common
+      - dejavu-sans-fonts
+      - dejavu-sans-mono-fonts
+      - dejavu-serif-fonts
+      - desktop-file-utils
+      - device-mapper
+      - device-mapper-libs
+      - diffutils
+      - docbook-dtds
+      - docbook-style-dsssl
+      - docbook-style-xsl
+      - docbook-utils
+      - dwz
+      - e2fsprogs
+      - e2fsprogs-devel
+      - e2fsprogs-libs
+      - efi-srpm-macros
+      - elfutils
+      - elfutils-default-yama-scope
+      - elfutils-devel
+      - elfutils-libelf
+      - elfutils-libelf-devel
+      - elfutils-libs
+      - elinks
+      - emacs-filesystem
+      - eosrei-emojione-fonts
+      - expat
+      - expat-devel
+      - fedora-gpg-keys
+      - fedora-release
+      - fedora-repos
+      - fedora-repos-rawhide
+      - file
+      - file-libs
+      - filesystem
+      - findutils
+      - fipscheck
+      - fipscheck-lib
+      - flac
+      - flac-devel
+      - flac-libs
+      - flatpak-runtime-config
+      - flex
+      - fontconfig
+      - fontconfig-devel
+      - fontpackages-filesystem
+      - fpc-srpm-macros
+      - freetype
+      - freetype-devel
+      - fribidi
+      - fribidi-devel
+      - fuse-libs
+      - gawk
+      - gc
+      - gcc
+      - gcc-c++
+      - gdb
+      - gdb-headless
+      - gdbm
+      - gdbm-devel
+      - gdbm-libs
+      - gdk-pixbuf2
+      - gdk-pixbuf2-devel
+      - gdk-pixbuf2-modules
+      - geoclue2
+      - geoclue2-devel
+      - geoclue2-libs
+      - gettext
+      - gettext-common-devel
+      - gettext-devel
+      - gettext-libs
+      - ghc-srpm-macros
+      - giflib
+      - giflib-devel
+      - git
+      - git-clang-format
+      - git-core
+      - git-core-doc
+      - git-cvs
+      - glib-networking
+      - glib2
+      - glib2-devel
+      - glibc
+      - glibc-all-langpacks
+      - glibc-common
+      - glibc-devel
+      - glibc-headers
+      - glibc-minimal-langpack
+      - gmp
+      - gmp-c++
+      - gmp-devel
+      - gnat-srpm-macros
+      - gnu-free-fonts-common
+      - gnu-free-mono-fonts
+      - gnu-free-sans-fonts
+      - gnu-free-serif-fonts
+      - gnupg
+      - gnupg2
+      - gnupg2-smime
+      - gnutls
+      - gnutls-c++
+      - gnutls-dane
+      - gnutls-devel
+      - gnutls-utils
+      - go-srpm-macros
+      - gobject-introspection
+      - gobject-introspection-devel
+      - google-crosextra-caladea-fonts
+      - google-crosextra-carlito-fonts
+      - gperf
+      - gpgme
+      - gpgme-devel
+      - gpm-libs
+      - graphite2
+      - graphite2-devel
+      - grep
+      - groff
+      - groff-base
+      - groff-perl
+      - gsettings-desktop-schemas
+      - gsettings-desktop-schemas-devel
+      - gsm
+      - gssdp
+      - gstreamer1
+      - gstreamer1-devel
+      - gstreamer1-plugins-bad-free
+      - gstreamer1-plugins-bad-free-devel
+      - gstreamer1-plugins-base
+      - gstreamer1-plugins-base-devel
+      - gtk-doc
+      - gtk-update-icon-cache
+      - gtk2
+      - gtk3
+      - gtk3-devel
+      - guile
+      - gupnp
+      - gupnp-igd
+      - gzip
+      - harfbuzz
+      - harfbuzz-devel
+      - harfbuzz-icu
+      - hicolor-icon-theme
+      - hunspell
+      - hunspell-devel
+      - hunspell-en-US
+      - hwdata
+      - hyphen
+      - hyphen-devel
+      - ibus
+      - ibus-devel
+      - ibus-gtk2
+      - ibus-gtk3
+      - ibus-libs
+      - ibus-setup
+      - icu
+      - info
+      - intltool
+      - iptables-libs
+      - isl
+      - iso-codes
+      - iso-codes-devel
+      - itstool
+      - jasper-libs
+      - jbigkit-libs
+      - jq
+      - jq-devel
+      - json-c
+      - json-c-devel
+      - json-glib
+      - json-glib-devel
+      - jsoncpp
+      - kernel-headers
+      - keyutils-libs
+      - keyutils-libs-devel
+      - kmod-libs
+      - krb5-devel
+      - krb5-libs
+      - krb5-server
+      - krb5-workstation
+      - lcms2
+      - lcms2-devel
+      - lcms2-utils
+      - less
+      - libICE
+      - libICE-devel
+      - libSM
+      - libSM-devel
+      - libX11
+      - libX11-common
+      - libX11-devel
+      - libX11-xcb
+      - libXScrnSaver
+      - libXScrnSaver-devel
+      - libXau
+      - libXau-devel
+      - libXaw
+      - libXcomposite
+      - libXcomposite-devel
+      - libXcursor
+      - libXcursor-devel
+      - libXdamage
+      - libXdamage-devel
+      - libXdmcp
+      - libXdmcp-devel
+      - libXext
+      - libXext-devel
+      - libXfixes
+      - libXfixes-devel
+      - libXft
+      - libXft-devel
+      - libXi
+      - libXi-devel
+      - libXinerama
+      - libXinerama-devel
+      - libXmu
+      - libXpm
+      - libXpm-devel
+      - libXrandr
+      - libXrandr-devel
+      - libXrender
+      - libXrender-devel
+      - libXt
+      - libXt-devel
+      - libXtst
+      - libXtst-devel
+      - libXv
+      - libXv-devel
+      - libXxf86misc
+      - libXxf86vm
+      - libXxf86vm-devel
+      - libacl
+      - libacl-devel
+      - libappstream-glib
+      - libappstream-glib-builder
+      - libappstream-glib-builder-devel
+      - libappstream-glib-devel
+      - libarchive
+      - libarchive-devel
+      - libargon2
+      - libassuan
+      - libassuan-devel
+      - libasyncns
+      - libatomic
+      - libatomic_ops
+      - libatomic_ops-devel
+      - libattr
+      - libattr-devel
+      - libbabeltrace
+      - libblkid
+      - libblkid-devel
+      - libcap
+      - libcap-devel
+      - libcap-ng
+      - libcom_err
+      - libcom_err-devel
+      - libcroco
+      - libcroco-devel
+      - libcurl
+      - libcurl-devel
+      - libdatrie
+      - libdatrie-devel
+      - libdb
+      - libdb-cxx
+      - libdb-cxx-devel
+      - libdb-devel
+      - libdb-utils
+      - libdrm
+      - libdrm-devel
+      - libdvdnav
+      - libdvdread
+      - libedit
+      - libedit-devel
+      - libepoxy
+      - libepoxy-devel
+      - liberation-fonts-common
+      - liberation-mono-fonts
+      - liberation-sans-fonts
+      - liberation-serif-fonts
+      - libev
+      - libevent
+      - libexif
+      - libexif-devel
+      - libfdisk
+      - libfdisk-devel
+      - libffi
+      - libffi-devel
+      - libgcab1
+      - libgcab1-devel
+      - libgcc
+      - libgcrypt
+      - libgcrypt-devel
+      - libgfortran
+      - libglvnd
+      - libglvnd-core-devel
+      - libglvnd-devel
+      - libglvnd-egl
+      - libglvnd-gles
+      - libglvnd-glx
+      - libglvnd-opengl
+      - libgomp
+      - libgpg-error
+      - libgpg-error-devel
+      - libgudev
+      - libgusb
+      - libicu
+      - libicu-devel
+      - libidn
+      - libidn-devel
+      - libidn2
+      - libipt
+      - libjpeg-turbo
+      - libjpeg-turbo-devel
+      - libkadm5
+      - libksba
+      - libmcpp
+      - libmetalink
+      - libmodman
+      - libmount
+      - libmount-devel
+      - libmpc
+      - libmpc-devel
+      - libmpcdec
+      - libnghttp2
+      - libnice
+      - libnotify
+      - libnsl
+      - libnsl2
+      - libnsl2-devel
+      - libogg
+      - libogg-devel
+      - libpcap
+      - libpciaccess
+      - libpciaccess-devel
+      - libpipeline
+      - libpkgconf
+      - libpng
+      - libpng-devel
+      - libproxy
+      - libproxy-devel
+      - libpsl
+      - libpwquality
+      - libquadmath
+      - librsvg2
+      - librsvg2-devel
+      - librsvg2-tools
+      - libsamplerate
+      - libsamplerate-devel
+      - libseccomp
+      - libseccomp-devel
+      - libsecret
+      - libselinux
+      - libselinux-devel
+      - libsemanage
+      - libsepol
+      - libsepol-devel
+      - libsigsegv
+      - libsmartcols
+      - libsmartcols-devel
+      - libsndfile
+      - libsndfile-devel
+      - libsoup
+      - libsoup-devel
+      - libsrtp
+      - libss
+      - libss-devel
+      - libssh
+      - libstdc++
+      - libstdc++-devel
+      - libstemmer
+      - libtasn1
+      - libtasn1-devel
+      - libtasn1-tools
+      - libthai
+      - libthai-devel
+      - libtheora
+      - libtheora-devel
+      - libtiff
+      - libtiff-devel
+      - libtirpc
+      - libtirpc-devel
+      - libtool
+      - libtool-ltdl
+      - libtool-ltdl-devel
+      - libunistring
+      - libusb
+      - libusbx
+      - libutempter
+      - libuuid
+      - libuuid-devel
+      - libuv
+      - libva
+      - libva-devel
+      - libva-utils
+      - libvdpau
+      - libvdpau-devel
+      - libvdpau-trace
+      - libverto
+      - libverto-devel
+      - libverto-libev
+      - libvisual
+      - libvorbis
+      - libvorbis-devel
+      - libvpx
+      - libvpx-devel
+      - libwayland-client
+      - libwayland-cursor
+      - libwayland-egl
+      - libwayland-server
+      - libwebp
+      - libwebp-devel
+      - libxcb
+      - libxcb-devel
+      - libxcrypt
+      - libxcrypt-devel
+      - libxkbcommon
+      - libxkbcommon-devel
+      - libxkbcommon-x11
+      - libxkbcommon-x11-devel
+      - libxkbfile
+      - libxml2
+      - libxml2-devel
+      - libxshmfence
+      - libxshmfence-devel
+      - libxslt
+      - libxslt-devel
+      - libyaml
+      - libyaml-devel
+      - libzstd
+      - llvm
+      - llvm-devel
+      - llvm-libs
+      - llvm6.0-libs
+      - logrotate
+      - lua-libs
+      - lz4-libs
+      - m4
+      - make
+      - man-db
+      - man2html-core
+      - mcpp
+      - mercurial
+      - mesa-filesystem
+      - mesa-libEGL
+      - mesa-libEGL-devel
+      - mesa-libGL
+      - mesa-libGL-devel
+      - mesa-libGLES
+      - mesa-libGLES-devel
+      - mesa-libgbm
+      - mesa-libgbm-devel
+      - mesa-libglapi
+      - mesa-libxatracker
+      - mesa-libxatracker-devel
+      - mesa-vulkan-devel
+      - mesa-vulkan-drivers
+      - meson
+      - mlocate
+      - mpfr
+      - mpfr-devel
+      - mpg123-devel
+      - mpg123-libs
+      - mythes
+      - mythes-devel
+      - nasm
+      - ncompress
+      - ncurses
+      - ncurses-base
+      - ncurses-c++-libs
+      - ncurses-compat-libs
+      - ncurses-devel
+      - ncurses-libs
+      - nettle
+      - nettle-devel
+      - nim-srpm-macros
+      - ninja-build
+      - npth
+      - nspr
+      - nspr-devel
+      - nss
+      - nss-devel
+      - nss-pkcs11-devel
+      - nss-softokn
+      - nss-softokn-devel
+      - nss-softokn-freebl
+      - nss-softokn-freebl-devel
+      - nss-sysinit
+      - nss-tools
+      - nss-util
+      - nss-util-devel
+      - nss_db
+      - nss_hesiod
+      - nss_nis
+      - numactl-libs
+      - ocaml-srpm-macros
+      - ocl-icd
+      - ocl-icd-devel
+      - oniguruma
+      - openal-soft
+      - openal-soft-devel
+      - openblas-srpm-macros
+      - opencl-headers
+      - openjade
+      - openjpeg2
+      - openldap
+      - opensp
+      - openssh
+      - openssh-clients
+      - openssl
+      - openssl-devel
+      - openssl-libs
+      - opus
+      - orc
+      - orc-compiler
+      - orc-devel
+      - p11-kit
+      - p11-kit-devel
+      - p11-kit-trust
+      - pam
+      - pam-devel
+      - pango
+      - pango-devel
+      - patch
+      - pcre
+      - pcre-cpp
+      - pcre-devel
+      - pcre-utf16
+      - pcre-utf32
+      - pcre2
+      - pcre2-devel
+      - pcre2-utf16
+      - pcre2-utf32
+      - perf
+      - perl-Algorithm-Diff
+      - perl-Archive-Tar
+      - perl-Archive-Zip
+      - perl-CPAN
+      - perl-CPAN-Meta
+      - perl-CPAN-Meta-Requirements
+      - perl-CPAN-Meta-YAML
+      - perl-Carp
+      - perl-Compress-Bzip2
+      - perl-Compress-Raw-Bzip2
+      - perl-Compress-Raw-Zlib
+      - perl-DBD-SQLite
+      - perl-DBI
+      - perl-Data-Dumper
+      - perl-Data-OptList
+      - perl-Data-Section
+      - perl-Devel-Size
+      - perl-Digest
+      - perl-Digest-MD5
+      - perl-Digest-SHA
+      - perl-Encode
+      - perl-Encode-devel
+      - perl-Errno
+      - perl-Error
+      - perl-Exporter
+      - perl-ExtUtils-CBuilder
+      - perl-ExtUtils-Command
+      - perl-ExtUtils-Install
+      - perl-ExtUtils-MM-Utils
+      - perl-ExtUtils-MakeMaker
+      - perl-ExtUtils-Manifest
+      - perl-ExtUtils-ParseXS
+      - perl-File-HomeDir
+      - perl-File-Path
+      - perl-File-Temp
+      - perl-File-Which
+      - perl-Filter
+      - perl-Getopt-Long
+      - perl-Git
+      - perl-HTTP-Tiny
+      - perl-IO
+      - perl-IO-Compress
+      - perl-IO-Socket-IP
+      - perl-IO-Zlib
+      - perl-IPC-Cmd
+      - perl-JSON-PP
+      - perl-Locale-Maketext
+      - perl-Locale-Maketext-Simple
+      - perl-MIME-Base64
+      - perl-MRO-Compat
+      - perl-Math-BigInt
+      - perl-Math-Complex
+      - perl-Module-Build
+      - perl-Module-CoreList
+      - perl-Module-CoreList-tools
+      - perl-Module-Load
+      - perl-Module-Load-Conditional
+      - perl-Module-Metadata
+      - perl-Net-Ping
+      - perl-Package-Generator
+      - perl-Params-Check
+      - perl-Params-Util
+      - perl-PathTools
+      - perl-Perl-OSType
+      - perl-Pod-Checker
+      - perl-Pod-Escapes
+      - perl-Pod-Html
+      - perl-Pod-Parser
+      - perl-Pod-Perldoc
+      - perl-Pod-Simple
+      - perl-Pod-Usage
+      - perl-SGMLSpm
+      - perl-Scalar-List-Utils
+      - perl-Socket
+      - perl-Software-License
+      - perl-Storable
+      - perl-Sub-Exporter
+      - perl-Sub-Install
+      - perl-Term-ANSIColor
+      - perl-Term-Cap
+      - perl-TermReadKey
+      - perl-Test-Harness
+      - perl-Text-Diff
+      - perl-Text-Glob
+      - perl-Text-ParseWords
+      - perl-Text-Tabs+Wrap
+      - perl-Text-Template
+      - perl-Text-Unidecode
+      - perl-Thread-Queue
+      - perl-Time-HiRes
+      - perl-Time-Local
+      - perl-URI
+      - perl-Unicode-EastAsianWidth
+      - perl-Unicode-Normalize
+      - perl-XML-Parser
+      - perl-XML-XPath
+      - perl-constant
+      - perl-devel
+      - perl-encoding
+      - perl-inc-latest
+      - perl-interpreter
+      - perl-libintl-perl
+      - perl-libnet
+      - perl-libnetcfg
+      - perl-libs
+      - perl-local-lib
+      - perl-macros
+      - perl-open
+      - perl-parent
+      - perl-podlators
+      - perl-srpm-macros
+      - perl-threads
+      - perl-threads-shared
+      - perl-utils
+      - perl-version
+      - pinentry
+      - pixman
+      - pixman-devel
+      - pkgconf
+      - pkgconf-m4
+      - pkgconf-pkg-config
+      - poppler
+      - poppler-data
+      - popt
+      - popt-devel
+      - procps-ng
+      - publicsuffix-list-dafsa
+      - pulseaudio-libs
+      - pulseaudio-libs-devel
+      - pulseaudio-libs-glib2
+      - pulseaudio-utils
+      - python-rpm-macros
+      - python-srpm-macros
+      - python-unversioned-command
+      - python2
+      - python2-devel
+      - python2-libproxy
+      - python2-libs
+      - python2-libxml2
+      - python2-mako
+      - python2-markupsafe
+      - python2-pip
+      - python2-rpm-macros
+      - python2-setuptools
+      - python3
+      - python3-cairo
+      - python3-devel
+      - python3-gobject
+      - python3-gobject-base
+      - python3-libs
+      - python3-libxml2
+      - python3-mako
+      - python3-markupsafe
+      - python3-pip
+      - python3-pyparsing
+      - python3-rpm-generators
+      - python3-rpm-macros
+      - python3-setuptools
+      - python3-six
+      - python36
+      - qrencode-libs
+      - qt5-srpm-macros
+      - readline
+      - readline-devel
+      - redhat-rpm-config
+      - rest
+      - rhash
+      - rpcgen
+      - rpcsvc-proto-devel
+      - rpm
+      - rpm-libs
+      - rpm-plugin-selinux
+      - ruby
+      - ruby-irb
+      - ruby-libs
+      - rubygem-io-console
+      - rubygem-json
+      - rubygem-openssl
+      - rubygem-psych
+      - rubygem-rake
+      - rubygem-rdoc
+      - rubygems
+      - rubypick
+      - rust-srpm-macros
+      - sed
+      - setup
+      - sgml-common
+      - shadow-utils
+      - shared-mime-info
+      - slang
+      - slang-slsh
+      - soundtouch
+      - source-highlight
+      - speex
+      - speex-devel
+      - speexdsp
+      - speexdsp-devel
+      - spirv-tools-libs
+      - sqlite
+      - sqlite-devel
+      - sqlite-libs
+      - strace
+      - subunit
+      - subunit-devel
+      - systemd
+      - systemd-libs
+      - systemd-pam
+      - systemtap-sdt-devel
+      - tar
+      - tcl
+      - tcl-devel
+      - texinfo
+      - texinfo-tex
+      - texlive-amsfonts
+      - texlive-base
+      - texlive-bibtex
+      - texlive-cm
+      - texlive-collection-basic
+      - texlive-dvipdfmx
+      - texlive-dvips
+      - texlive-enctex
+      - texlive-epsf
+      - texlive-etex
+      - texlive-etex-pkg
+      - texlive-glyphlist
+      - texlive-graphics-def
+      - texlive-gsftopk
+      - texlive-hyph-utf8
+      - texlive-hyphen-base
+      - texlive-ifluatex
+      - texlive-ifxetex
+      - texlive-knuth-lib
+      - texlive-knuth-local
+      - texlive-kpathsea
+      - texlive-latex-fonts
+      - texlive-lib
+      - texlive-lua-alt-getopt
+      - texlive-luatex
+      - texlive-makeindex
+      - texlive-metafont
+      - texlive-mflogo
+      - texlive-mfware
+      - texlive-pdftex
+      - texlive-plain
+      - texlive-tetex
+      - texlive-tex
+      - texlive-tex-ini-files
+      - texlive-texconfig
+      - texlive-texlive-common-doc
+      - texlive-texlive-docindex
+      - texlive-texlive-en
+      - texlive-texlive-msg-translations
+      - texlive-texlive-scripts
+      - texlive-texlive.infra
+      - texlive-unicode-data
+      - texlive-updmap-map
+      - texlive-xdvi
+      - tk
+      - turbojpeg
+      - turbojpeg-devel
+      - tzdata
+      - unbound-libs
+      - unzip
+      - util-linux
+      - vala
+      - valgrind
+      - valgrind-devel
+      - valgrind-tools-devel
+      - vim-filesystem
+      - vim-minimal
+      - vulkan-headers
+      - vulkan-loader
+      - vulkan-loader-devel
+      - vulkan-validation-layers
+      - vulkan-validation-layers-devel
+      - wayland-devel
+      - wayland-protocols-devel
+      - webrtc-audio-processing
+      - which
+      - words
+      - xcb-proto
+      - xcb-util
+      - xcb-util-cursor
+      - xcb-util-cursor-devel
+      - xcb-util-devel
+      - xcb-util-image
+      - xcb-util-image-devel
+      - xcb-util-keysyms
+      - xcb-util-keysyms-devel
+      - xcb-util-renderutil
+      - xcb-util-renderutil-devel
+      - xcb-util-wm
+      - xcb-util-wm-devel
+      - xdg-user-dirs
+      - xdg-utils
+      - xkeyboard-config
+      - xkeyboard-config-devel
+      - xml-common
+      - xorg-x11-proto-devel
+      - xorg-x11-server-utils
+      - xorg-x11-util-macros
+      - xorg-x11-xauth
+      - xorg-x11-xinit
+      - xorg-x11-xkb-utils
+      - xorg-x11-xtrans-devel
+      - xz
+      - xz-devel
+      - xz-libs
+      - xz-lzma-compat
+      - yasm
+      - zenity
+      - zip
+      - zlib
+      - zlib-devel
+      - zziplib
+  api:
+    rpms:
+    - flatpak-rpm-macros
+    - flatpak-runtime-config
+  components:
+    rpms:
+      flatpak-rpm-macros:
+        rationale: Set up build root for flatpak RPMS
+        repository: git+https://src.fedoraproject.org/rpms/flatpak-rpm-macros
+        cache: https://src.fedoraproject.org/repo/pkgs/flatpak-rpm-macros
+        ref: master
+      flatpak-runtime-config:
+        rationale: Runtime configuration files
+        repository: git+https://src.fedoraproject.org/rpms/flatpak-runtime-config
+        cache: https://src.fedoraproject.org/repo/pkgs/flatpak-runtime-config
+        ref: master
+  artifacts:
+    rpms:
+    - flatpak-rpm-macros-0:27-6.module_2021+15e5e3e7.noarch
+    - flatpak-runtime-config-0:27-7.module_2021+15e5e3e7.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: eog
+  stream: master
+  version: 20180821163756
+  context: 775baa8e
+  arch: x86_64
+  summary: Eye of GNOME Application Module
+  description: >
+    The Eye of GNOME image viewer (eog) is the official image viewer for the GNOME
+    desktop. It can view single image files in a variety of formats, as well as large
+    image collections.
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+    - GPLv2+ and GFDL
+    - GPLv2+ and LGPLv2+
+    - LGPLv2+
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/eog.git?#375e2f73492aba2a9c8c892b5152d588e553c19c
+      commit: 375e2f73492aba2a9c8c892b5152d588e553c19c
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        flatpak-runtime:
+          ref: 2b45d61997c37c41f4cc127842f01d30024db74d
+          stream: f29
+          context: 6c81f848
+          version: 20180820180704
+          filtered_rpms: []
+      rpms:
+        eog:
+          ref: 96166844a72788cd7e6fc278aeedc1e3da5ec816
+        libpeas:
+          ref: 8e162f875ac7e00dd90f3d791d40484f91012415
+        gnome-desktop3:
+          ref: 981addd1ddeee303df8518e479439cd9e4478c66
+        bubblewrap:
+          ref: aaaaaae81d69644c0502125b338a4c86ff2e0a0e
+        exempi:
+          ref: ab39221162cac7c025060a14cac712c73b38b431
+  dependencies:
+  - buildrequires:
+      flatpak-runtime: [f29]
+    requires:
+      flatpak-runtime: [f29]
+  profiles:
+    default:
+      rpms:
+      - eog
+  components:
+    rpms:
+      bubblewrap:
+        rationale: Runtime dependency.
+        repository: git+https://src.fedoraproject.org/rpms/bubblewrap
+        cache: https://src.fedoraproject.org/repo/pkgs/bubblewrap
+        ref: f29
+      eog:
+        rationale: Application package
+        repository: git+https://src.fedoraproject.org/rpms/eog
+        cache: https://src.fedoraproject.org/repo/pkgs/eog
+        ref: f29
+        buildorder: 1
+      exempi:
+        rationale: Runtime dependency.
+        repository: git+https://src.fedoraproject.org/rpms/exempi
+        cache: https://src.fedoraproject.org/repo/pkgs/exempi
+        ref: f29
+      gnome-desktop3:
+        rationale: Runtime dependency.
+        repository: git+https://src.fedoraproject.org/rpms/gnome-desktop3
+        cache: https://src.fedoraproject.org/repo/pkgs/gnome-desktop3
+        ref: f29
+      libpeas:
+        rationale: Runtime dependency.
+        repository: git+https://src.fedoraproject.org/rpms/libpeas
+        cache: https://src.fedoraproject.org/repo/pkgs/libpeas
+        ref: f29
+  artifacts:
+    rpms:
+    - bubblewrap-0:0.3.0-2.module_2123+73a9ef6f.x86_64
+    - eog-0:3.28.3-1.module_2123+73a9ef6f.x86_64
+    - eog-devel-0:3.28.3-1.module_2123+73a9ef6f.x86_64
+    - eog-tests-0:3.28.3-1.module_2123+73a9ef6f.x86_64
+    - exempi-0:2.4.5-3.module_2123+73a9ef6f.x86_64
+    - exempi-devel-0:2.4.5-3.module_2123+73a9ef6f.x86_64
+    - gnome-desktop3-0:3.29.90.1-1.module_2123+73a9ef6f.x86_64
+    - gnome-desktop3-devel-0:3.29.90.1-1.module_2123+73a9ef6f.x86_64
+    - gnome-desktop3-tests-0:3.29.90.1-1.module_2123+73a9ef6f.x86_64
+    - libpeas-0:1.22.0-9.module_2123+73a9ef6f.x86_64
+    - libpeas-devel-0:1.22.0-9.module_2123+73a9ef6f.x86_64
+    - libpeas-gtk-0:1.22.0-9.module_2123+73a9ef6f.x86_64
+    - libpeas-loader-python3-0:1.22.0-9.module_2123+73a9ef6f.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: dwm
+  stream: latest
+  version: 20180814184656
+  context: 6c81f848
+  arch: x86_64
+  summary: Dynamic window manager for X
+  description: >-
+    dwm is a dynamic window manager for X.  It manages windows in tiled, monocle,
+    and floating layouts.  All of the layouts can be applied dynamically, optimizing
+    the environment for the application in use and the task performed.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/dwm.git?#bde94bfe3c38c6c064c8dd484fe2e638768fae7b
+      commit: bde94bfe3c38c6c064c8dd484fe2e638768fae7b
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        dwm:
+          ref: b85c993bf46a22fcdfa017f2c16e135bc578c3be
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://suckless.org/
+    documentation: https://dwm.suckless.org/
+  profiles:
+    default:
+      description: The minimal, distribution-compiled dwm binary.
+      rpms:
+      - dwm
+    user:
+      description: Includes distrribution-compiled dwm as well as a helper script
+        to apply user patches and configuration, dwm-user.
+      rpms:
+      - dwm
+      - dwm-user
+  components:
+    rpms:
+      dwm:
+        rationale: The main component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/dwm
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/dwm
+        ref: latest
+  artifacts:
+    rpms:
+    - dwm-0:6.1-1.20180602gitb69c870.module_2012+7328f38d.x86_64
+    - dwm-user-0:6.1-1.20180602gitb69c870.module_2012+7328f38d.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: dwm
+  stream: 6.1
+  version: 20180813122714
+  context: 6c81f848
+  arch: x86_64
+  summary: Dynamic window manager for X
+  description: >-
+    dwm is a dynamic window manager for X.  It manages windows in tiled, monocle,
+    and floating layouts.  All of the layouts can be applied dynamically, optimizing
+    the environment for the application in use and the task performed.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/dwm.git?#8f0dc77f8e89fe04a44c3bb3a77dec21d3c4a9dd
+      commit: 8f0dc77f8e89fe04a44c3bb3a77dec21d3c4a9dd
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        dwm:
+          ref: 62a7aa6320bb31e6140ddae9eeeb7e98963d31a3
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://suckless.org/
+    documentation: https://dwm.suckless.org/
+  profiles:
+    default:
+      description: The minimal, distribution-compiled dwm binary.
+      rpms:
+      - dwm
+    user:
+      description: Includes distrribution-compiled dwm as well as a helper script
+        to apply user patches and configuration, dwm-user.
+      rpms:
+      - dwm
+      - dwm-user
+  api:
+    rpms:
+    - dwm
+    - dwm-user
+  components:
+    rpms:
+      dwm:
+        rationale: The main component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/dwm
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/dwm
+        ref: 6.1
+  artifacts:
+    rpms:
+    - dwm-0:6.1-8.module_1995+c3e93812.x86_64
+    - dwm-user-0:6.1-8.module_1995+c3e93812.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: dwm
+  stream: 6.0
+  version: 20180813144159
+  context: 6c81f848
+  arch: x86_64
+  summary: Dynamic window manager for X
+  description: >-
+    dwm is a dynamic window manager for X.  It manages windows in tiled, monocle,
+    and floating layouts.  All of the layouts can be applied dynamically, optimizing
+    the environment for the application in use and the task performed.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/dwm.git?#9b78dc232c321e9e8c93bd55f7e95dc113459a39
+      commit: 9b78dc232c321e9e8c93bd55f7e95dc113459a39
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        dwm:
+          ref: 43decc0e45e7fe8286356b3a51f64e05f13f3823
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://suckless.org/
+    documentation: https://dwm.suckless.org/
+  profiles:
+    default:
+      description: The minimal, distribution-compiled dwm binary.
+      rpms:
+      - dwm
+    user:
+      description: Includes distrribution-compiled dwm as well as a helper script
+        to apply user patches and configuration, dwm-user.
+      rpms:
+      - dwm
+      - dwm-user
+  api:
+    rpms:
+    - dwm
+    - dwm-user
+  components:
+    rpms:
+      dwm:
+        rationale: The main component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/dwm
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/dwm
+        ref: 6.0
+  artifacts:
+    rpms:
+    - dwm-0:6.0-1.module_1997+c375c79c.x86_64
+    - dwm-user-0:6.0-1.module_1997+c375c79c.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: docker
+  stream: 2017.0
+  version: 20180816194539
+  context: 3ff668f0
+  arch: x86_64
+  summary: Module for docker runtime and docker-distribution
+  description: >-
+    Docker is an open-source engine that automates the deployment of any application
+    as a lightweight, portable, self-sufficient container that will run virtually
+    anywhere.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+    - GPLv2
+    - LGPLv3
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/docker.git?#3dd5060deeb1517577c78b0259f94530fc2aae15
+      commit: 3dd5060deeb1517577c78b0259f94530fc2aae15
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        golang:
+          ref: 92882e9696b779110fd27aa11ddbc88f30eb82a2
+          stream: 1.10
+          context: 6c81f848
+          version: 20180816140129
+          filtered_rpms: []
+        golang-ecosystem:
+          ref: 384b17a75c5c9be71c913651126d6899e42e8d84
+          stream: 2017.0
+          context: cbfb2833
+          version: 20180816154241
+          filtered_rpms: []
+      rpms:
+        docker:
+          ref: 7c17c91d74be490fe27a5a8c0a7e7ed4307a735d
+        docker-distribution:
+          ref: 215123409e61eecb1b5d6e4fb5b4b63196674b2e
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      container-tools: [2017.0]
+      platform: [f29]
+  references:
+    community: htts://github.com/projectatomic/docker
+    documentation: https://github.com/projectatomic/docker
+    tracker: https://github.com/projectatomic/docker
+  profiles:
+    default:
+      rpms:
+      - docker
+      - docker-distribution
+  api:
+    rpms:
+    - docker
+    - docker-common
+    - docker-distribution
+    - docker-fish-completion
+    - docker-logrotate
+    - docker-lvm-plugin
+    - docker-novolume-plugin
+    - docker-rhel-push-plugin
+    - docker-vim
+    - docker-zsh-completion
+  components:
+    rpms:
+      docker:
+        rationale: Primary component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/docker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/docker
+        ref: f28
+      docker-distribution:
+        rationale: Primary component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/docker-distribution
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/docker-distribution
+        ref: f28
+  artifacts:
+    rpms:
+    - docker-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-common-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-devel-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.noarch
+    - docker-distribution-0:2.6.2-7.git48294d9.module_1641+02d06da9.x86_64
+    - docker-fish-completion-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-logrotate-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-lvm-plugin-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-novolume-plugin-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-rhel-push-plugin-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-unit-test-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-vim-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+    - docker-zsh-completion-2:1.13.1-61.git9cb56fd.module_2109+7c83ead1.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: django
+  stream: 1.6
+  version: 20180828135711
+  context: 6c81f848
+  arch: x86_64
+  summary: A high-level Python Web framework
+  description: >-
+    Django is a high-level Python Web framework that encourages rapid development
+    and a clean, pragmatic design. It focuses on automating as much as possible and
+    adhering to the DRY (Don't Repeat Yourself) principle.
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/django.git?#da53d66d3db1aa5f6afd75887b00fa26849bcc0a
+      commit: da53d66d3db1aa5f6afd75887b00fa26849bcc0a
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        python-django:
+          ref: 9e50c9cc5cc0bd23e92ee58b2b2ffa14effad0a0
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://www.djangoproject.com
+    documentation: https://docs.djangoproject.com
+    tracker: https://code.djangoproject.com/query
+  profiles:
+    default:
+      rpms:
+      - python2-django
+    python2_development:
+      rpms:
+      - python2-django
+  api:
+    rpms:
+    - python2-django
+  components:
+    rpms:
+      python-django:
+        rationale: The Django python web framework
+        repository: git+https://src.fedoraproject.org/rpms/python-django
+        cache: https://src.fedoraproject.org/repo/pkgs/python-django
+        ref: 1.6
+  artifacts:
+    rpms:
+    - python-django-bash-completion-0:1.6.11.7-3.module_2144+ad479803.noarch
+    - python2-django-0:1.6.11.7-3.module_2144+ad479803.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: cri-o
+  stream: 2018.0
+  version: 20180529183952
+  context: 3ff668f0
+  arch: x86_64
+  summary: Kubernetes Container Runtime Interface for OCI-based containers
+  description: >-
+    CRI-O is the Kubernetes Container Runtime Interface for OCI-based containers.
+  license:
+    module:
+    - ASL 2.0
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/cri-o.git?#8c90882569bc8a63408be7b634bc2c094533e3a3
+      commit: 8c90882569bc8a63408be7b634bc2c094533e3a3
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+        golang:
+          ref: d6ad30745aef89e89b266908b713ea92fe73a834
+          stream: 1.10
+          context: 6c81f848
+          version: 20180529132243
+          filtered_rpms: []
+        golang-ecosystem:
+          ref: 698fdf86122ea5f47cc89793a05ce841e0e0023b
+          stream: 2017.0
+          context: 05251d78
+          version: 20180409165640
+          filtered_rpms: []
+      rpms:
+        cri-o:
+          ref: 4746e937b245100643f2efcbe90ef154a717c9e6
+        cri-tools:
+          ref: a5b6369696fd69fcb7242837428dd2f836cbc2df
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      container-tools: [2017.0]
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/modularity-modules/docker
+    tracker: https://github.com/modularity-modules/cri-o
+  profiles:
+    default:
+      rpms:
+      - cri-o
+      - cri-tools
+  api:
+    rpms:
+    - conmon
+    - cri-o
+    - cri-tools
+  components:
+    rpms:
+      cri-o:
+        rationale: Primary component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/cri-o
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/cri-o
+        ref: f28
+      cri-tools:
+        rationale: Primary component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/cri-tools
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/cri-tools
+        ref: f28
+  artifacts:
+    rpms:
+    - conmon-2:1.10.1-1.git728df92.module_1818+7c6ae394.x86_64
+    - cri-o-2:1.10.1-1.git728df92.module_1818+7c6ae394.x86_64
+    - cri-o-integration-tests-2:1.10.1-1.git728df92.module_1818+7c6ae394.x86_64
+    - cri-tools-0:1.0.0-5.gitf6ed14e.module_1818+7c6ae394.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: cri-o
+  stream: 2017.0
+  version: 20180816135947
+  context: 3ff668f0
+  arch: x86_64
+  summary: Kubernetes Container Runtime Interface for OCI-based containers
+  description: >-
+    CRI-O is the Kubernetes Container Runtime Interface for OCI-based containers.
+  license:
+    module:
+    - ASL 2.0
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/cri-o.git?#ea55eba4c063a7a5dc36991edbf010e2b8df3e49
+      commit: ea55eba4c063a7a5dc36991edbf010e2b8df3e49
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        golang:
+          ref: d6ad30745aef89e89b266908b713ea92fe73a834
+          stream: 1.10
+          context: 6c81f848
+          version: 20180529132243
+          filtered_rpms: []
+        golang-ecosystem:
+          ref: 4188f37999c72f87bab2b59dab2bc14fa31bbee2
+          stream: 2017.0
+          context: cbfb2833
+          version: 20180724154421
+          filtered_rpms: []
+      rpms:
+        cri-o:
+          ref: 5650cabcd0105a7c42d1a396af36f674be82a812
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      container-tools: [2017.0]
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/modularity-modules/docker
+    tracker: https://github.com/modularity-modules/cri-o
+  profiles:
+    default:
+      rpms:
+      - cri-o
+  api:
+    rpms:
+    - conmon
+    - cri-o
+  components:
+    rpms:
+      cri-o:
+        rationale: Primary component of this module.
+        repository: git://pkgs.fedoraproject.org/rpms/cri-o
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/cri-o
+        ref: f28
+  artifacts:
+    rpms:
+    - conmon-2:1.11.1-1.git1759204.module_2042+335cf4b5.x86_64
+    - cri-o-2:1.11.1-1.git1759204.module_2042+335cf4b5.x86_64
+    - cri-o-integration-tests-2:1.11.1-1.git1759204.module_2042+335cf4b5.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: cri-o
+  stream: 1.11
+  version: 20180827233205
+  context: 6c81f848
+  arch: x86_64
+  summary: Kubernetes Container Runtime Interface for OCI-based containers
+  description: >-
+    CRI-O is the Kubernetes Container Runtime Interface for OCI-based containers.
+  license:
+    module:
+    - ASL 2.0
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/cri-o.git?#17501669e29cfdcb41346f2fe31e2c4196a408e8
+      commit: 17501669e29cfdcb41346f2fe31e2c4196a408e8
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        cri-o:
+          ref: c759c453e3c9c3d33fa9bb740ab15d49a3ee987e
+        cri-tools:
+          ref: 4285d2f99d8a75678bf185da32ae19a44a3c4f08
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://github.com/modularity-modules/docker
+    tracker: https://github.com/modularity-modules/cri-o
+  profiles:
+    default:
+      rpms:
+      - cri-o
+      - cri-tools
+  api:
+    rpms:
+    - conmon
+    - cri-o
+    - cri-tools
+  components:
+    rpms:
+      cri-o:
+        rationale: Primary component of this module.
+        repository: git+https://src.fedoraproject.org/rpms/cri-o
+        cache: https://src.fedoraproject.org/repo/pkgs/cri-o
+        ref: 1.11
+      cri-tools:
+        rationale: Primary component of this module.
+        repository: git+https://src.fedoraproject.org/rpms/cri-tools
+        cache: https://src.fedoraproject.org/repo/pkgs/cri-tools
+        ref: 1.11
+  artifacts:
+    rpms:
+    - conmon-2:1.11.2-2.git3eac3b2.module_2141+e7e01fef.x86_64
+    - cri-o-2:1.11.2-2.git3eac3b2.module_2141+e7e01fef.x86_64
+    - cri-tools-0:1.11.1-1.git404b126.module_2138+be1ea703.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: container-tools
+  stream: 2018.0
+  version: 20180816194520
+  context: cb85db27
+  arch: x86_64
+  summary: Common tools and dependencies for container runtimes
+  description: >-
+    Contains SELinux policies, binaries and other dependencies for use with container
+    runtimes
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+    - GPLv2
+    - GPLv3+
+    - LGPLv2+
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/container-tools.git?#31b761077ffd9f584efa534c16a3aed454aef977
+      commit: 31b761077ffd9f584efa534c16a3aed454aef977
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        golang:
+          ref: 92882e9696b779110fd27aa11ddbc88f30eb82a2
+          stream: 1.10
+          context: 6c81f848
+          version: 20180816140129
+          filtered_rpms: []
+        golang-ecosystem:
+          ref: 1654fad1d9abf46a7d4f7845ea9e847b762f08a5
+          stream: 2018.0
+          context: cbfb2833
+          version: 20180816154327
+          filtered_rpms: []
+      rpms:
+        atomic:
+          ref: 6cec22f4c5825958a7a702586a1f8bb8aa15f854
+        python-docker-pycreds:
+          ref: 5347f5fb0029c9664a0e5de07d733747568cd08d
+        containernetworking-cni:
+          ref: 5741bb6612f10603e0b40306e6eaaffb8067a22d
+        skopeo:
+          ref: 37201821cfb686ab9a5009fe8b066982978e2458
+        buildah:
+          ref: 430c7a0285af77ab4a462568cb07f9f8f0c83cf2
+        python-docker:
+          ref: 2807ee649da39b46336a79f4795d0ed2d8b496cf
+        container-selinux:
+          ref: 02a599cecb197d9c2261d1af30e4895e806f7bca
+        container-storage-setup:
+          ref: fa451e89ac98aa45131ca68d35f47197d863deb0
+        oci-register-machine:
+          ref: 9c3980edbc2cdcede251b59b24faddf495c7d1b4
+        podman:
+          ref: c92ca272fcee01526152095c12516e8091040524
+        oci-umount:
+          ref: 14f111761a8e6691eb88589d58be4db35a9fa727
+        python-varlink:
+          ref: a7229e7b3653cd920028a7dc50aa223e7fcd8778
+        oci-systemd-hook:
+          ref: 7b9e5e15cba8f89cf729b6580e46fe3e3fb18c11
+        runc:
+          ref: 9f4d6de82cac64f4604d12676e322c7d30661962
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://github.com/projectatomic
+    documentation: https://projectatomic.io
+    tracker: https://github.com/projectatomic
+  profiles:
+    default:
+      rpms:
+      - atomic
+      - buildah
+      - container-selinux
+      - container-storage-setup
+      - containernetworking-cni
+      - oci-register-machine
+      - oci-systemd-hook
+      - oci-umount
+      - podman
+      - python-docker
+      - python-docker-pycreds
+      - python-varlink
+      - runc
+      - skopeo
+  api:
+    rpms:
+    - atomic
+    - atomic-registries
+    - buildah
+    - container-selinux
+    - container-storage-setup
+    - containernetworking-cni
+    - oci-register-machine
+    - oci-systemd-hook
+    - oci-umount
+    - podman
+    - python2-docker
+    - python2-docker-pycreds
+    - python3-docker
+    - python3-docker-pycreds
+    - python3-podman
+    - python3-varlink
+    - runc
+    - skopeo
+    - skopeo-containers
+  buildopts:
+    rpms:
+      macros: |
+        %_with_ignore_tests 1
+  components:
+    rpms:
+      atomic:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/atomic
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/atomic
+        ref: f28
+        buildorder: 1
+      buildah:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/buildah
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/buildah
+        ref: f28
+      container-selinux:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/container-selinux
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/container-selinux
+        ref: f28
+      container-storage-setup:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/container-storage-setup
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/container-storage-setup
+        ref: f28
+      containernetworking-cni:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/containernetworking-cni
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/containernetworking-cni
+        ref: f28
+      oci-register-machine:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/oci-register-machine
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/oci-register-machine
+        ref: f28
+      oci-systemd-hook:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/oci-systemd-hook
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/oci-systemd-hook
+        ref: f28
+      oci-umount:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/oci-umount
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/oci-umount
+        ref: f28
+      podman:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/podman
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/podman
+        ref: f28
+        buildorder: 1
+      python-docker:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/python-docker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-docker
+        ref: f28
+      python-docker-pycreds:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/python-docker-pycreds
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-docker-pycreds
+        ref: f28
+      python-varlink:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/python-varlink
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-varlink
+        ref: f28
+      runc:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/runc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/runc
+        ref: f28
+      skopeo:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/skopeo
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/skopeo
+        ref: f28
+  artifacts:
+    rpms:
+    - atomic-0:1.22.1-2.module_1816+29c6bc78.x86_64
+    - atomic-registries-0:1.22.1-2.module_1816+29c6bc78.x86_64
+    - buildah-0:1.3-1.git4888163.module_2106+3b446c4f.x86_64
+    - container-selinux-2:2.69-3.git452b90d.module_2106+3b446c4f.noarch
+    - container-storage-setup-0:0.11.0-1.git42c9d9c.module_2106+3b446c4f.noarch
+    - containernetworking-cni-0:0.7.1-1.module_2106+3b446c4f.x86_64
+    - containernetworking-cni-devel-0:0.7.1-1.module_2106+3b446c4f.noarch
+    - containernetworking-cni-unit-test-devel-0:0.7.1-1.module_2106+3b446c4f.x86_64
+    - containers-common-0:0.1.31-14.dev.gitb0b750d.module_2106+3b446c4f.x86_64
+    - oci-register-machine-0:0-7.1.git66fa845.module_1816+29c6bc78.x86_64
+    - oci-systemd-hook-1:0.1.17-3.gitbd86a79.module_2106+3b446c4f.x86_64
+    - oci-umount-2:2.3.4-1.git87f9237.module_1816+29c6bc78.x86_64
+    - podman-0:0.8.2.1-1.gitf38eb4f.module_2106+3b446c4f.x86_64
+    - podman-docker-0:0.8.2.1-1.gitf38eb4f.module_2106+3b446c4f.noarch
+    - python2-docker-0:3.2.1-1.module_1816+29c6bc78.noarch
+    - python2-docker-pycreds-0:0.2.2-2.module_1816+29c6bc78.noarch
+    - python2-docker-tests-0:3.2.1-1.module_1816+29c6bc78.noarch
+    - python3-docker-0:3.2.1-1.module_1816+29c6bc78.noarch
+    - python3-docker-pycreds-0:0.2.2-2.module_1816+29c6bc78.noarch
+    - python3-podman-0:0.8.2.1-1.gitf38eb4f.module_2106+3b446c4f.noarch
+    - python3-pypodman-0:0.8.2.1-1.gitf38eb4f.module_2106+3b446c4f.noarch
+    - python3-varlink-0:27.1.1-1.module_2106+3b446c4f.noarch
+    - runc-2:1.0.0-50.dev.git20aff4f.module_2106+3b446c4f.x86_64
+    - skopeo-0:0.1.31-14.dev.gitb0b750d.module_2106+3b446c4f.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: container-tools
+  stream: 2017.0
+  version: 20180816194450
+  context: 80bd9113
+  arch: x86_64
+  summary: Common tools and dependencies for container runtimes
+  description: >-
+    Contains SELinux policies, binaries and other dependencies for use with container
+    runtimes
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+    - GPLv2
+    - GPLv3+
+    - LGPLv2+
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/container-tools.git?#eef39c487fcfdffb12a4a18d3fccec8f0ea48d35
+      commit: eef39c487fcfdffb12a4a18d3fccec8f0ea48d35
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+        golang:
+          ref: 92882e9696b779110fd27aa11ddbc88f30eb82a2
+          stream: 1.10
+          context: 6c81f848
+          version: 20180816140129
+          filtered_rpms: []
+        golang-ecosystem:
+          ref: 384b17a75c5c9be71c913651126d6899e42e8d84
+          stream: 2017.0
+          context: cbfb2833
+          version: 20180816154241
+          filtered_rpms: []
+      rpms:
+        atomic:
+          ref: 6cec22f4c5825958a7a702586a1f8bb8aa15f854
+        python-docker-pycreds:
+          ref: 5347f5fb0029c9664a0e5de07d733747568cd08d
+        skopeo:
+          ref: 37201821cfb686ab9a5009fe8b066982978e2458
+        python-docker:
+          ref: 2807ee649da39b46336a79f4795d0ed2d8b496cf
+        buildah:
+          ref: 430c7a0285af77ab4a462568cb07f9f8f0c83cf2
+        container-selinux:
+          ref: 02a599cecb197d9c2261d1af30e4895e806f7bca
+        oci-register-machine:
+          ref: 9c3980edbc2cdcede251b59b24faddf495c7d1b4
+        container-storage-setup:
+          ref: fa451e89ac98aa45131ca68d35f47197d863deb0
+        oci-umount:
+          ref: 14f111761a8e6691eb88589d58be4db35a9fa727
+        runc:
+          ref: 9f4d6de82cac64f4604d12676e322c7d30661962
+        oci-systemd-hook:
+          ref: 7b9e5e15cba8f89cf729b6580e46fe3e3fb18c11
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: https://github.com/projectatomic
+    documentation: https://projectatomic.io
+    tracker: https://github.com/projectatomic
+  profiles:
+    default:
+      rpms:
+      - atomic
+      - buildah
+      - container-selinux
+      - container-storage-setup
+      - oci-register-machine
+      - oci-systemd-hook
+      - oci-umount
+      - python-docker
+      - python-docker-pycreds
+      - runc
+      - skopeo
+  api:
+    rpms:
+    - atomic
+    - atomic-registries
+    - buildah
+    - container-selinux
+    - container-storage-setup
+    - oci-register-machine
+    - oci-systemd-hook
+    - oci-umount
+    - python2-docker
+    - python2-docker-pycreds
+    - python3-docker
+    - python3-docker-pycreds
+    - runc
+    - skopeo
+    - skopeo-containers
+  buildopts:
+    rpms:
+      macros: |
+        %_with_ignore_tests 1
+  components:
+    rpms:
+      atomic:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/atomic
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/atomic
+        ref: f28
+      buildah:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/buildah
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/buildah
+        ref: f28
+      container-selinux:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/container-selinux
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/container-selinux
+        ref: f28
+      container-storage-setup:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/container-storage-setup
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/container-storage-setup
+        ref: f28
+      oci-register-machine:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/oci-register-machine
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/oci-register-machine
+        ref: f28
+      oci-systemd-hook:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/oci-systemd-hook
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/oci-systemd-hook
+        ref: f28
+      oci-umount:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/oci-umount
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/oci-umount
+        ref: f28
+      python-docker:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/python-docker
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-docker
+        ref: f28
+      python-docker-pycreds:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/python-docker-pycreds
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-docker-pycreds
+        ref: f28
+      runc:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/runc
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/runc
+        ref: f28
+      skopeo:
+        rationale: Primary component of this module
+        repository: git://pkgs.fedoraproject.org/rpms/skopeo
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/skopeo
+        ref: f28
+  artifacts:
+    rpms:
+    - atomic-0:1.22.1-2.module_1637+1872e86a.x86_64
+    - atomic-registries-0:1.22.1-2.module_1637+1872e86a.x86_64
+    - buildah-0:1.3-1.git4888163.module_2040+0e96cf1b.x86_64
+    - container-selinux-2:2.69-3.git452b90d.module_2040+0e96cf1b.noarch
+    - container-storage-setup-0:0.11.0-1.git42c9d9c.module_2040+0e96cf1b.noarch
+    - containers-common-0:0.1.31-14.dev.gitb0b750d.module_2040+0e96cf1b.x86_64
+    - oci-register-machine-0:0-7.1.git66fa845.module_1637+1872e86a.x86_64
+    - oci-systemd-hook-1:0.1.17-3.gitbd86a79.module_2040+0e96cf1b.x86_64
+    - oci-umount-2:2.3.4-1.git87f9237.module_1637+1872e86a.x86_64
+    - python2-docker-0:3.2.1-1.module_1637+1872e86a.noarch
+    - python2-docker-pycreds-0:0.2.2-2.module_1637+1872e86a.noarch
+    - python2-docker-tests-0:3.2.1-1.module_1637+1872e86a.noarch
+    - python3-docker-0:3.2.1-1.module_1637+1872e86a.noarch
+    - python3-docker-pycreds-0:0.2.2-2.module_1637+1872e86a.noarch
+    - runc-2:1.0.0-50.dev.git20aff4f.module_2040+0e96cf1b.x86_64
+    - skopeo-0:0.1.31-14.dev.gitb0b750d.module_2040+0e96cf1b.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: avocado
+  stream: stable
+  version: 20180816135414
+  context: 6c81f848
+  arch: x86_64
+  summary: Framework with tools and libraries for Automated Testing
+  description: >-
+    Avocado is a set of tools and libraries (what people call these days a framework)
+    to perform automated testing.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2
+    - GPLv2 and MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/avocado.git?#10208a3095f9522485b933dbab830e3338af95e6
+      commit: 10208a3095f9522485b933dbab830e3338af95e6
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        python-avocado:
+          ref: 87dc683a36d0862340d3af99b78fa189a1aba424
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://avocado-framework.github.io/
+    documentation: http://avocado-framework.readthedocs.io/
+    tracker: https://github.com/avocado-framework/avocado/issues
+  profiles:
+    default:
+      rpms:
+      - python2-avocado
+      - python2-avocado-plugins-output-html
+      - python2-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      rpms:
+      - python2-avocado
+  api:
+    rpms:
+    - python-avocado-examples
+    - python2-avocado
+    - python2-avocado-plugins-output-html
+    - python2-avocado-plugins-resultsdb
+    - python2-avocado-plugins-runner-docker
+    - python2-avocado-plugins-runner-remote
+    - python2-avocado-plugins-runner-vm
+    - python2-avocado-plugins-varianter-yaml-to-mux
+  components:
+    rpms:
+      python-avocado:
+        rationale: Framework with tools and libraries for Automated Testing
+        repository: git://pkgs.fedoraproject.org/rpms/python-avocado
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-avocado
+        ref: master
+  artifacts:
+    rpms:
+    - python-avocado-examples-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-output-html-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-resultsdb-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-docker-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-remote-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-vm-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-varianter-yaml-to-mux-0:52.1-7.module_1939+1f9e88da.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: avocado
+  stream: latest
+  version: 20180816135607
+  context: 6c81f848
+  arch: x86_64
+  summary: Framework with tools and libraries for Automated Testing
+  description: >-
+    Avocado is a set of tools and libraries (what people call these days a framework)
+    to perform automated testing.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2
+    - GPLv2 and MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/avocado.git?#3649cb2aa51fb496395bb2846addd70b72945543
+      commit: 3649cb2aa51fb496395bb2846addd70b72945543
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        python-avocado:
+          ref: 1454277ea964bafcdf51803035e3369517d03774
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://avocado-framework.github.io/
+    documentation: http://avocado-framework.readthedocs.io/
+    tracker: https://github.com/avocado-framework/avocado/issues
+  profiles:
+    default:
+      description: Default profile installing the most commonly used avocado packages.
+      rpms:
+      - python2-avocado
+      - python2-avocado-plugins-output-html
+      - python2-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      description: Minimal profile installing only the main avocado package.
+      rpms:
+      - python2-avocado
+  api:
+    rpms:
+    - python-avocado-bash
+    - python-avocado-common
+    - python-avocado-examples
+    - python2-avocado
+    - python2-avocado-plugins-glib
+    - python2-avocado-plugins-golang
+    - python2-avocado-plugins-loader-yaml
+    - python2-avocado-plugins-output-html
+    - python2-avocado-plugins-result-upload
+    - python2-avocado-plugins-resultsdb
+    - python2-avocado-plugins-runner-docker
+    - python2-avocado-plugins-runner-remote
+    - python2-avocado-plugins-runner-vm
+    - python2-avocado-plugins-varianter-pict
+    - python2-avocado-plugins-varianter-yaml-to-mux
+    - python3-avocado
+    - python3-avocado-plugins-glib
+    - python3-avocado-plugins-golang
+    - python3-avocado-plugins-loader-yaml
+    - python3-avocado-plugins-output-html
+    - python3-avocado-plugins-result-upload
+    - python3-avocado-plugins-varianter-pict
+    - python3-avocado-plugins-varianter-yaml-to-mux
+  components:
+    rpms:
+      python-avocado:
+        rationale: Framework with tools and libraries for Automated Testing
+        repository: git://pkgs.fedoraproject.org/rpms/python-avocado
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-avocado
+        ref: latest
+  artifacts:
+    rpms:
+    - python-avocado-bash-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python-avocado-common-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python-avocado-examples-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-glib-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-golang-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-loader-yaml-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-output-html-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-result-upload-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-resultsdb-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-runner-docker-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-runner-remote-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-runner-vm-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-varianter-pict-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python2-avocado-plugins-varianter-yaml-to-mux-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python3-avocado-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python3-avocado-plugins-glib-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python3-avocado-plugins-golang-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python3-avocado-plugins-loader-yaml-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python3-avocado-plugins-output-html-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python3-avocado-plugins-result-upload-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python3-avocado-plugins-varianter-pict-0:63.0-2.module_1958+f0d1ec4b.noarch
+    - python3-avocado-plugins-varianter-yaml-to-mux-0:63.0-2.module_1958+f0d1ec4b.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: ant
+  stream: 1.10
+  version: 20180629154141
+  context: 819b5873
+  arch: x86_64
+  summary: Java build tool
+  description: >-
+    Apache Ant is a Java library and command-line tool whose mission is to drive processes
+    described in build files as targets and extension points dependent upon each other.
+    The main known usage of Ant is the build of Java applications. Ant supplies a
+    number of built-in tasks allowing to compile, assemble, test and run Java applications.
+    Ant can also be used effectively to build non Java applications, for instance
+    C or C++ applications. More generally, Ant can be used to pilot any type of process
+    which can be described in terms of targets and tasks.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/ant.git?#efb686945a977ec8322eca2401e96e8da0f4e3f2
+      commit: efb686945a977ec8322eca2401e96e8da0f4e3f2
+      buildrequires:
+        javapackages-tools:
+          ref: 1e429a4d686d3fdd1d93ce7e8ac7254148ea3471
+          stream: 201801
+          context: b43b0c8f
+          version: 20180629150827
+          filtered_rpms: []
+        platform:
+          ref: virtual
+          stream: f28
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        ant:
+          ref: 1b60ebd3ac34e2c4648c4a5377c9e51fc44d658c
+  dependencies:
+  - requires:
+      platform: []
+  profiles:
+    default:
+      rpms:
+      - ant
+  api:
+    rpms:
+    - ant
+  filter:
+    rpms:
+    - ant-antlr
+    - ant-apache-bcel
+    - ant-apache-bsf
+    - ant-apache-log4j
+    - ant-apache-oro
+    - ant-apache-regexp
+    - ant-apache-resolver
+    - ant-apache-xalan2
+    - ant-commons-logging
+    - ant-commons-net
+    - ant-javadoc
+    - ant-javamail
+    - ant-jdepend
+    - ant-jmf
+    - ant-jsch
+    - ant-junit
+    - ant-manual
+    - ant-swing
+    - ant-testutil
+    - ant-xz
+  buildopts:
+    rpms:
+      macros: |
+        %_with_xmvn_javadoc 1
+        %_without_asciidoc 1
+        %_without_avalon 1
+        %_without_bouncycastle 1
+        %_without_cython 1
+        %_without_dafsa 1
+        %_without_desktop 1
+        %_without_doxygen 1
+        %_without_dtd 1
+        %_without_eclipse 1
+        %_without_ehcache 1
+        %_without_emacs 1
+        %_without_equinox 1
+        %_without_fop 1
+        %_without_ftp 1
+        %_without_gradle 1
+        %_without_groovy 1
+        %_without_hadoop 1
+        %_without_hsqldb 1
+        %_without_itext 1
+        %_without_jackson 1
+        %_without_jmh 1
+        %_without_jna 1
+        %_without_jpa 1
+        %_without_junit5 1
+        %_without_logback 1
+        %_without_markdown 1
+        %_without_memcached 1
+        %_without_memoryfilesystem 1
+        %_without_obr 1
+        %_without_python 1
+        %_without_reporting 1
+        %_without_scm 1
+        %_without_snappy 1
+        %_without_spring 1
+        %_without_ssh 1
+        %_without_testlib 1
+  components:
+    rpms:
+      ant:
+        rationale: 'Module API.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/ant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/ant
+        ref: javapackages
+        buildorder: 10
+  artifacts:
+    rpms:
+    - ant-0:1.10.4-1.module_1886+ece9a977.noarch
+    - ant-lib-0:1.10.4-1.module_1886+ece9a977.noarch
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: nodejs
+  profiles:
+    6: [default]
+    8: [default]
+    9: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: reviewboard
+  profiles:
+    2.5: [default]
+    3.0: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: ant
+  profiles:
+    1.10: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: dwm
+  stream: 6.1
+  profiles:
+    6.0: [default]
+    6.1: [default]
+    latest: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: maven
+  profiles:
+    3.5: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: django
+  profiles:
+    1.6: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: stratis
+  stream: 1
+  profiles:
+    1: [default]
+...

--- a/ModulemdTranslationHelpers/tests/test_data/f29_build_1.yaml
+++ b/ModulemdTranslationHelpers/tests/test_data/f29_build_1.yaml
@@ -1,0 +1,130 @@
+document: modulemd
+version: 2
+data:
+  name: ant
+  stream: 1.10
+  version: 20180629154141
+  context: 819b5873
+  arch: x86_64
+  summary: Java build tool
+  description: >-
+    Apache Ant is a Java library and command-line tool whose mission is to drive processes
+    described in build files as targets and extension points dependent upon each other.
+    The main known usage of Ant is the build of Java applications. Ant supplies a
+    number of built-in tasks allowing to compile, assemble, test and run Java applications.
+    Ant can also be used effectively to build non Java applications, for instance
+    C or C++ applications. More generally, Ant can be used to pilot any type of process
+    which can be described in terms of targets and tasks.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/ant.git?#efb686945a977ec8322eca2401e96e8da0f4e3f2
+      commit: efb686945a977ec8322eca2401e96e8da0f4e3f2
+      buildrequires:
+        javapackages-tools:
+          ref: 1e429a4d686d3fdd1d93ce7e8ac7254148ea3471
+          stream: 201801
+          context: b43b0c8f
+          version: 20180629150827
+          filtered_rpms: []
+        platform:
+          ref: virtual
+          stream: f28
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        ant:
+          ref: 1b60ebd3ac34e2c4648c4a5377c9e51fc44d658c
+  dependencies:
+  - requires:
+      platform: []
+  profiles:
+    default:
+      rpms:
+      - ant
+  api:
+    rpms:
+    - ant
+  filter:
+    rpms:
+    - ant-antlr
+    - ant-apache-bcel
+    - ant-apache-bsf
+    - ant-apache-log4j
+    - ant-apache-oro
+    - ant-apache-regexp
+    - ant-apache-resolver
+    - ant-apache-xalan2
+    - ant-commons-logging
+    - ant-commons-net
+    - ant-javadoc
+    - ant-javamail
+    - ant-jdepend
+    - ant-jmf
+    - ant-jsch
+    - ant-junit
+    - ant-manual
+    - ant-swing
+    - ant-testutil
+    - ant-xz
+  buildopts:
+    rpms:
+      macros: |
+        %_with_xmvn_javadoc 1
+        %_without_asciidoc 1
+        %_without_avalon 1
+        %_without_bouncycastle 1
+        %_without_cython 1
+        %_without_dafsa 1
+        %_without_desktop 1
+        %_without_doxygen 1
+        %_without_dtd 1
+        %_without_eclipse 1
+        %_without_ehcache 1
+        %_without_emacs 1
+        %_without_equinox 1
+        %_without_fop 1
+        %_without_ftp 1
+        %_without_gradle 1
+        %_without_groovy 1
+        %_without_hadoop 1
+        %_without_hsqldb 1
+        %_without_itext 1
+        %_without_jackson 1
+        %_without_jmh 1
+        %_without_jna 1
+        %_without_jpa 1
+        %_without_junit5 1
+        %_without_logback 1
+        %_without_markdown 1
+        %_without_memcached 1
+        %_without_memoryfilesystem 1
+        %_without_obr 1
+        %_without_python 1
+        %_without_reporting 1
+        %_without_scm 1
+        %_without_snappy 1
+        %_without_spring 1
+        %_without_ssh 1
+        %_without_testlib 1
+  components:
+    rpms:
+      ant:
+        rationale: 'Module API.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/ant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/ant
+        ref: javapackages
+        buildorder: 10
+  artifacts:
+    rpms:
+    - ant-0:1.10.4-1.module_1886+ece9a977.noarch
+    - ant-lib-0:1.10.4-1.module_1886+ece9a977.noarch
+    

--- a/ModulemdTranslationHelpers/tests/test_data/f29_build_2.yaml
+++ b/ModulemdTranslationHelpers/tests/test_data/f29_build_2.yaml
@@ -1,0 +1,78 @@
+document: modulemd
+version: 2
+data:
+  name: avocado
+  stream: stable
+  version: 20180816135414
+  context: 6c81f848
+  arch: x86_64
+  summary: Framework with tools and libraries for Automated Testing
+  description: >-
+    Avocado is a set of tools and libraries (what people call these days a framework)
+    to perform automated testing.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2
+    - GPLv2 and MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/avocado.git?#10208a3095f9522485b933dbab830e3338af95e6
+      commit: 10208a3095f9522485b933dbab830e3338af95e6
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        python-avocado:
+          ref: 87dc683a36d0862340d3af99b78fa189a1aba424
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://avocado-framework.github.io/
+    documentation: http://avocado-framework.readthedocs.io/
+    tracker: https://github.com/avocado-framework/avocado/issues
+  profiles:
+    default:
+      rpms:
+      - python2-avocado
+      - python2-avocado-plugins-output-html
+      - python2-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      rpms:
+      - python2-avocado
+  api:
+    rpms:
+    - python-avocado-examples
+    - python2-avocado
+    - python2-avocado-plugins-output-html
+    - python2-avocado-plugins-resultsdb
+    - python2-avocado-plugins-runner-docker
+    - python2-avocado-plugins-runner-remote
+    - python2-avocado-plugins-runner-vm
+    - python2-avocado-plugins-varianter-yaml-to-mux
+  components:
+    rpms:
+      python-avocado:
+        rationale: Framework with tools and libraries for Automated Testing
+        repository: git://pkgs.fedoraproject.org/rpms/python-avocado
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-avocado
+        ref: master
+  artifacts:
+    rpms:
+    - python-avocado-examples-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-output-html-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-resultsdb-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-docker-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-remote-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-vm-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-varianter-yaml-to-mux-0:52.1-7.module_1939+1f9e88da.noarch

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 # This file is part of ModulemdTranslationHelpers
-# Copyright (C) 2018 Stephen Gallagher
+# Copyright (C) 2018-2019 Stephen Gallagher
 #
 # Fedora-License-Identifier: MIT
 # SPDX-2.0-License-Identifier: MIT
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='ModulemdTranslationHelpers',
-    version='0.6',
+    version='1.0',
     packages=['ModulemdTranslationHelpers'],
     url='https://github.com/fedora-modularity/ModulemdTranslationHelpers',
     license='MIT',
@@ -40,6 +40,8 @@ setup(
         'console_scripts': [
             'ModulemdTranslationHelpers=ModulemdTranslationHelpers.cli:cli'],
     },
+    test_suite='nose.collector',
+    tests_require=['nose'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This is migrating from
https://github.com/fedora-modularity/libmodulemd/tree/822e50006333ffdc717a152dbe17f94acbc98b92

It does not modify cli.py yet to use the new library. That will
come in a follow-up patch.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>